### PR TITLE
Allow bcolz kwargs to pass thru

### DIFF
--- a/into/backends/bcolz.py
+++ b/into/backends/bcolz.py
@@ -1,6 +1,5 @@
 from __future__ import absolute_import, division, print_function
 
-import bcolz
 import os
 from bcolz import ctable, carray
 import numpy as np
@@ -10,12 +9,11 @@ from datashape import discover
 import shutil
 from ..append import append
 from ..convert import convert, ooc_types
-from ..create import create
 from ..resource import resource
-from ..chunks import chunks, Chunks
 from ..drop import drop
+from ..chunks import chunks
 
-keywords = ['rootdir']
+keywords = ['cparams', 'dflt', 'expectedlen', 'chunklen', 'rootdir']
 
 
 @discover.register((ctable, carray))
@@ -76,7 +74,7 @@ def resource_bcolz(uri, dshape=None, **kwargs):
     else:
         if not dshape:
             raise ValueError("Must specify either existing bcolz directory or"
-                    " valid datashape")
+                             " valid datashape")
         dshape = datashape.dshape(dshape)
 
         dt = datashape.to_numpy_dtype(dshape)

--- a/into/backends/tests/test_bcolz.py
+++ b/into/backends/tests/test_bcolz.py
@@ -1,9 +1,9 @@
 from __future__ import absolute_import, division, print_function
 
-from into.backends.bcolz import (create, append, convert, ctable, carray,
-        resource, discover, drop)
+from into.backends.bcolz import (append, convert, ctable, carray, resource,
+                                 discover, drop)
 from into.chunks import chunks
-from into import into, append, convert, resource, discover
+from into import append, convert, resource, discover
 import numpy as np
 from into.utils import tmpfile
 import os


### PR DESCRIPTION
`expectedlen` is very important here. `bcolz` chooses the chunk size based on the `expectedlen` which may not be known by `blaze` or expensive to compute so the user should be able to pass this information through if they have access to it

@mrocklin what do you think about possibly inferring the `expectedlen` where we can? for backends where the row count is cheap to compute we could do this when folks are appending to or creating a new `bcolz` table.
