### PR TITLE
ENH: glob for S3 CSVs

### DIFF
--- a/docs/source/aws.rst
+++ b/docs/source/aws.rst
@@ -33,12 +33,23 @@ Interface
 URIs
 ----
 
-To access an S3 bucket, simply provide the path to the S3 bucket prefixed with
+To access an S3 key, simply provide the path to the S3 key prefixed with
 ``s3://``
 
     .. code-block:: python
 
        >>> csvfile = resource('s3://bucket/key.csv')
+
+S3 commonly uses a ``prefix`` to limit an operation to a subset of keys.
+We can simulate a glob of keys by combining a ``prefix`` with the ``*`` character:
+
+    .. code-block:: python
+
+       >>> csv_glob = resource('s3://bucket/prefix*.csv')
+
+This will match all keys with starting with ``prefix`` and ending with the ``.csv``
+extension. The result ``csv_glob`` can be used just like a glob of files from your
+local disk.
 
 Accessing a Redshift database is the same as accessing it through SQLAlchemy
 


### PR DESCRIPTION
@cpcloud this would be super useful for me. Redshift dumps a (gzipped) CSV per node.

My questions:

- priority? I think I took the same as the CSV glob
- Better way to list the keys matching the glob than creating a new S3 connection inside `resource_s3_csv_glob`?
- ~~It doesn't actually work yet... is there another step to hook this up to the network?~~ 
- tests
- is there a better path to hook into than directly from `chunks(s3(CSV)) -> chunks(DataFrame)`?

I've only spent 1-2 hours on this and I'll continue to work on it. I'm just guessing that some of these will be easier for you to answer :)