### PR TITLE
Make unit_to_dtype aware of Option(Decimal) types

### DIFF
--- a/odo/numpy_dtype.py
+++ b/odo/numpy_dtype.py
@@ -23,6 +23,8 @@ def unit_to_dtype(ds):
     if isinstance(ds, DataShape):
         ds = ds.measure
     if isinstance(ds, Option) and isscalar(ds) and isnumeric(ds):
+        if isinstance(ds.ty, Decimal):
+            return unit_to_dtype(str(ds.ty.to_numpy_dtype()).replace('int', 'float'))
         return unit_to_dtype(str(ds).replace('int', 'float').replace('?', ''))
     if isinstance(ds, Option) and isinstance(ds.ty, (type(date_),
             type(datetime_), type(string), type(timedelta_))):

--- a/odo/numpy_dtype.py
+++ b/odo/numpy_dtype.py
@@ -4,6 +4,8 @@ import numpy as np
 from datashape import *
 from datashape.predicates import isscalar, isnumeric
 
+from .utils import ignoring
+
 def unit_to_dtype(ds):
     """
 
@@ -23,8 +25,9 @@ def unit_to_dtype(ds):
     if isinstance(ds, DataShape):
         ds = ds.measure
     if isinstance(ds, Option) and isscalar(ds) and isnumeric(ds):
-        if isinstance(ds.ty, Decimal):
-            return unit_to_dtype(str(ds.ty.to_numpy_dtype()).replace('int', 'float'))
+        with ignoring(NameError):
+            if isinstance(ds.ty, Decimal):
+                return unit_to_dtype(str(ds.ty.to_numpy_dtype()).replace('int', 'float'))
         return unit_to_dtype(str(ds).replace('int', 'float').replace('?', ''))
     if isinstance(ds, Option) and isinstance(ds.ty, (type(date_),
             type(datetime_), type(string), type(timedelta_))):

--- a/odo/tests/test_numpy_dtype.py
+++ b/odo/tests/test_numpy_dtype.py
@@ -20,3 +20,15 @@ def test_parameterized_option_instances():
     dshape4 = datashape.dshape('option[timedelta[unit="D"]]')
     nptype4 = unit_to_dtype(dshape4)
     assert isinstance(nptype4, np.dtype)
+
+    dshape5 = datashape.dshape('decimal[9,2]')
+    nptype5 = unit_to_dtype(dshape5)
+    assert nptype5 == np.float64
+
+    dshape6 = datashape.dshape('decimal[9]')
+    nptype6 = unit_to_dtype(dshape6)
+    assert nptype6 == np.int32
+
+    dshape7 = datashape.dshape('?decimal[9]')
+    nptype7 = unit_to_dtype(dshape7)
+    assert nptype7 == np.float32


### PR DESCRIPTION
The Decimal type I introduced in blaze/datashape#170 has `to_numpy_dtype()` defined to downcast the Decimal types to NumPy ints and floats, but odo will not recognize Option versions of these Decimals without this fix. I also added tests to verify this.

This does introduce a dependency on the datashape version that will contain Decimals. Not sure if that needs to be addressed here or not... I was thinking of wrapping the `unit_to_dtype` new code in a `with ignoring(NameError):` block, which will solve this issue, but the tests will still fail in that case.