### PR TITLE
Update the docs

### DIFF
--- a/docs/source/datashape.rst
+++ b/docs/source/datashape.rst
@@ -62,7 +62,7 @@ But we want this one::
 What is DataShape?
 ------------------
 
-Datashape is a datatype system that includes scalar types::
+DataShape is a datatype system that includes scalar types::
 
     string, int32, float64, datetime, ...
 
@@ -135,9 +135,9 @@ datashape is only a guess and might need to be tweaked.
    >>> odo('accounts.csv', pd.DataFrame, dshape=ds)
 
 In these cases we can copy-paste the datashape and modify the parts that we
-need to change.  In the example above we couldn't call discover directly on the
-URI, ``'accounts.csv'`` so instead we called ``resource`` on the URI first.
-Discover returns the datashape ``string`` on all strings, regardless of whether
+need to change.  In the example above we couldn't call ``discover`` directly on the
+URI, ``'accounts.csv'``, so instead we called ``resource`` on the URI first.
+``discover`` returns the datashape ``string`` on all strings, regardless of whether
 or not we intend them to be URIs.
 
 Learn More

--- a/docs/source/functions.rst
+++ b/docs/source/functions.rst
@@ -1,7 +1,7 @@
-Five Operations
+Four Operations
 ===============
 
-The Blaze project originally included ``odo.into`` as a magic function that
+The Blaze project originally included ``odo.odo`` as a magic function that
 moved data between containers.  This function was both sufficiently
 useful and sufficiently magical that it was moved to a separate project, its
 functionality separated into three operations

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,6 +1,6 @@
 Odo: Shapeshifting for your data
 ================================
-``odo`` takes two arguments, a target and a source for a data transfer.
+``odo`` takes two arguments, a source and a target for a data transfer.
 
 .. code-block:: python
 

--- a/docs/source/overview.rst
+++ b/docs/source/overview.rst
@@ -9,7 +9,7 @@ data on remote machines, and the Hadoop File System.
 The ``odo`` function
 --------------------
 
-``odo`` takes two arguments, a target and a source for a data transfer.
+``odo`` takes two arguments, a source and a target for a data transfer.
 
 .. code-block:: python
 
@@ -23,11 +23,11 @@ The target and source can take on the following forms
 .. table::
 
    ====== ====== ======================================================
-   Target Source Example
+   Source Target Example
    ====== ====== ======================================================
    Object Object An instance of a ``DataFrame`` or ``list``
    String String ``'file.csv'``, ``'postgresql://hostname::tablename'``
-   Type          ``list``, ``DataFrame``
+          Type   ``list``, ``DataFrame``
    ====== ====== ======================================================
 
 So the following lines would be valid inputs to ``odo``
@@ -47,7 +47,7 @@ So the following lines would be valid inputs to ``odo``
 Network Effects
 ---------------
 
-To convert data any pair of formats ``odo.into`` relies on a network of
+To convert data any pair of formats ``odo.odo`` relies on a network of
 pairwise conversions.  We visualize that network below
 
 .. figure:: images/conversions.png

--- a/docs/source/uri.rst
+++ b/docs/source/uri.rst
@@ -51,7 +51,7 @@ within the file.  For example we refer to the table ``accounts`` in a Postgres d
 
     postgresql://localhost::accounts
 
-In this case the separator ``::`` separtates the database
+In this case the separator ``::`` separates the database
 ``postgreqsl://localhost`` from the table within the database, ``accounts``.
 
 This also occurs in HDF5 files which have an internal datapath::
@@ -107,7 +107,7 @@ When we use a string in ``odo`` this is actually just shorthand for calling
 Notably, URIs are just syntactic sugar, you don't have to use them.  You can
 always construct the object explicitly.  Odo invents very few types,
 preferring instead to use standard projects within the Python ecosystem like
-``sqlalchemy.Table`` or ``pymongo.Collection``.  If your applicaiton also uses
+``sqlalchemy.Table`` or ``pymongo.Collection``.  If your application also uses
 these types then it's likely that ``odo`` already works with your data.
 
 


### PR DESCRIPTION
- Fix some typos and MarkDown errors
- Rename `odo.into` to `odo.odo` as needed
- Reorder source/target to reflect the order they're passed as