### PR TITLE
ENH: pass convert function the edges they are connecting

### DIFF
--- a/odo/core.py
+++ b/odo/core.py
@@ -38,12 +38,19 @@ def _transform(graph, target, source, excluded_edges=None, ooc_types=ooc_types,
     with ignoring(NotImplementedError):
         if 'dshape' not in kwargs:
             kwargs['dshape'] = discover(x)
+
     pth = path(graph, type(source), target,
                excluded_edges=excluded_edges,
                ooc_types=ooc_types)
     try:
         for (A, B, f) in pth:
-            x = f(x, excluded_edges=excluded_edges, **kwargs)
+            kwargs['converting_from'] = A
+            kwargs['converting_to'] = B
+            x = f(
+                x,
+                excluded_edges=excluded_edges,
+                **kwargs
+            )
         return x
     except NotImplementedError as e:
         if kwargs.get('raise_on_errors'):

--- a/odo/tests/test_core.py
+++ b/odo/tests/test_core.py
@@ -53,3 +53,23 @@ def test_ooc_behavior():
     ooc = set([A, C])
     assert [(a, b) for a, b, func in path(foo.graph, A, C, ooc_types=ooc)] == \
                         [(A, C)]
+
+
+def test_convert_passes_extras():
+    foo = NetworkDispatcher('foo')
+    class A(object): pass
+    class B(object): pass
+
+    discover.register(lambda x: 'int')
+
+    kwargs = {}
+
+    @foo.register(B, A, cost=1.0)
+    def _(a, **k):
+        kwargs.update(k)
+        return 1
+
+    assert foo(B, A()) == 1
+
+    assert kwargs['converting_from'] is A
+    assert kwargs['converting_to'] is B


### PR DESCRIPTION
I am trying to use some proxy types in a graph.

Ideally I could create a class like:

``` python
class Any(metaclass=ABCMeta):
    @classmethod
    def __subclasshook__(cls, subcls):
        return True
```

and then write a some converter like:

``` python
@convert.register(Any, Proxy, cost=1.0)
def _(p, converting_to=None, **kwargs):
    if isinstance(p.data, converting_to):
        return p.data
    raise NotImplemented()
```

to hook my proxy into the graph.

As a heuristic for now, I can replace `Any` with `object.__subclasses__()` (though that is sort of scary

Also, if you have a suggestion for a better way to do this, please let me know.
