### PR TITLE
ENH: Adds nan->pd.NaT edge

### DIFF
--- a/docs/source/whatsnew/0.3.5.txt
+++ b/docs/source/whatsnew/0.3.5.txt
@@ -39,6 +39,9 @@ None
 Bug Fixes
 ---------
 
+* Pandas backend now supports conversion from `nan` to `pandas.NaT`
+  (:issue:`331`).
+
 None
 
 Miscellaneous

--- a/odo/backends/pandas.py
+++ b/odo/backends/pandas.py
@@ -8,6 +8,7 @@ from datashape import float32, float64, string, Option, object_, datetime_
 import datashape
 
 import pandas as pd
+import numpy as np
 
 from ..convert import convert
 
@@ -67,3 +68,11 @@ def coerce_datetimes(df):
 @convert.register(pd.Timestamp, datetime)
 def convert_datetime_to_timestamp(dt, **kwargs):
     return pd.Timestamp(dt)
+
+
+@convert.register(pd.Timestamp, float)
+def nan_to_nat(fl, **kwargs):
+    if np.isnan(fl):
+        # Only nan->nat edge
+        return pd.NaT
+    raise NotImplementedError()

--- a/odo/backends/tests/test_pandas.py
+++ b/odo/backends/tests/test_pandas.py
@@ -4,7 +4,9 @@ from datetime import datetime
 
 from datashape import discover, Option
 from datashape import dshape
+from networkx import NetworkXNoPath
 import pandas as pd
+import pytest
 
 from odo import odo
 
@@ -37,3 +39,11 @@ def test_datetime_to_timestamp():
     ts = odo(dt, pd.Timestamp)
     assert isinstance(ts, pd.Timestamp)
     assert ts == pd.Timestamp('2014-01-01')
+
+
+def test_nan_to_nat():
+    assert odo(float('nan'), pd.Timestamp) is pd.NaT
+
+    with pytest.raises(NetworkXNoPath):
+        # Check that only nan can be converted.
+        odo(0.5, pd.Timestamp)


### PR DESCRIPTION
Currently reductions on series of dtype datetime64 which are empty result in a `nan` instead of ` pd.NaT` which causes things like:

```python
odo(pd.Series(dtype='datetime64[ns]').max(), pd.Timestamp)
```

to fail by not finding a route from `float -> pd.Timestamp`

I have a pr for pandas (https://github.com/pydata/pandas/pull/11245) that changes return to nat in pandas land but this solves the immediate issue.