### PR TITLE
BUG: fix the nan_to_nat edge

### DIFF
--- a/docs/source/whatsnew/0.4.0.txt
+++ b/docs/source/whatsnew/0.4.0.txt
@@ -28,6 +28,8 @@ Improved Backends
 
 * Pandas now includes an edge from ``datetime.datetime`` to
   ``pandas.Timestamp`` (:issue:`329`).
+* Pandas now includes an edge from ``NoneType`` to ``pandas.Timestamp``
+  (:issue:`3321).
 
 None
 

--- a/docs/source/whatsnew/0.4.0.txt
+++ b/docs/source/whatsnew/0.4.0.txt
@@ -28,7 +28,9 @@ Improved Backends
 
 * Pandas now includes an edge from ``datetime.datetime`` to
   ``pandas.Timestamp`` (:issue:`329`).
-* Pandas now includes an edge from ``NoneType`` to ``pandas.Timestamp``
+* Pandas now includes an edge from ``NoneType`` to ``pandas.Timestamp``.
+  Pandas now includes an edge from
+  ``pandas.tslib.NaTType`` to ``pandas.Timestamp``
   (:issue:`3321).
 
 None

--- a/odo/backends/pandas.py
+++ b/odo/backends/pandas.py
@@ -23,7 +23,7 @@ def discover_dataframe(df):
     dtypes = list(map(datashape.CType.from_numpy_dtype, df.dtypes))
     dtypes = [string if dt == obj else dt for dt in dtypes]
     odtypes = [Option(dt) if dt in possibly_missing else dt
-                for dt in dtypes]
+               for dt in dtypes]
     schema = datashape.Record(list(zip(names, odtypes)))
     return len(df) * schema
 
@@ -81,6 +81,6 @@ def nan_to_nat(fl, **kwargs):
     raise NotImplementedError()
 
 
-@convert.register(pd.Timestamp, type(None))
-def none_to_nat(n, **kwargs):
+@convert.register(pd.Timestamp, (pd.tslib.NaTType, type(None)))
+def convert_null_or_nat_to_nat(n, **kwargs):
     return pd.NaT

--- a/odo/backends/pandas.py
+++ b/odo/backends/pandas.py
@@ -72,7 +72,10 @@ def convert_datetime_to_timestamp(dt, **kwargs):
 
 @convert.register(pd.Timestamp, float)
 def nan_to_nat(fl, **kwargs):
-    if np.isnan(fl):
-        # Only nan->nat edge
-        return pd.NaT
+    try:
+        if np.isnan(fl):
+            # Only nan->nat edge
+            return pd.NaT
+    except TypeError:
+        pass
     raise NotImplementedError()

--- a/odo/backends/pandas.py
+++ b/odo/backends/pandas.py
@@ -79,3 +79,8 @@ def nan_to_nat(fl, **kwargs):
     except TypeError:
         pass
     raise NotImplementedError()
+
+
+@convert.register(pd.Timestamp, type(None))
+def none_to_nat(n, **kwargs):
+    return pd.NaT

--- a/odo/backends/tests/test_pandas.py
+++ b/odo/backends/tests/test_pandas.py
@@ -49,3 +49,7 @@ def test_nan_to_nat():
     with pytest.raises(NetworkXNoPath):
         # Check that only nan can be converted.
         odo(0.5, pd.Timestamp)
+
+
+def test_none_to_nat():
+    assert odo(None, pd.Timestamp) is pd.NaT

--- a/odo/backends/tests/test_pandas.py
+++ b/odo/backends/tests/test_pandas.py
@@ -53,3 +53,7 @@ def test_nan_to_nat():
 
 def test_none_to_nat():
     assert odo(None, pd.Timestamp) is pd.NaT
+
+
+def test_nat_to_nat():
+    assert odo(pd.NaT, pd.Timestamp) is pd.NaT


### PR DESCRIPTION
This edge would get called with non float arguments which caused a
typeerror to be raised. This is now caught and a notimplemented error is
raised so that convert can work around this.


I was prototyping something that would typecheck all of our conversion; however, this actually would cause something like what I have here to break. The main issue is that we have things like:

```
@convert.register(base, sa.sql.Select, cost=300.0)
def select_to_base(sel, dshape=None, bind=None, **kwargs):
```

Where we never check that the thing returned is the particular base that was passed. What was happening was the route looked like select->float->timestamp; however, the sql->float edge was returning a datetime. I think that having the source and destination passed to the function would let one of these generic converters do the type checking internally. Also, we could make `typecheck=False` argument to convert.register so that these can be checked in odo.core.