### PR TITLE
BUG: Remove nonetype edges from bokeh module when not installed.

### DIFF
--- a/odo/backends/bokeh.py
+++ b/odo/backends/bokeh.py
@@ -1,21 +1,24 @@
 from __future__ import absolute_import, division, print_function
 
-from ..convert import convert
 import pandas as pd
-try:
+
+from ..convert import convert
+from ..utils import ignoring
+
+
+with ignoring(ImportError):
     from bokeh.models import ColumnDataSource
-except ImportError:
-    ColumnDataSource = type(None)
-
-@convert.register(pd.DataFrame, ColumnDataSource)
-def columndatasource_to_dataframe(cds, **kwargs):
-    df = cds.to_df()
-    return df[sorted(df.columns)]
 
 
-@convert.register(ColumnDataSource, pd.DataFrame)
-def dataframe_to_columndatasource(df, **kwargs):
-    d = ColumnDataSource.from_df(df)
-    if 'index' in d:
-        d.pop('index')
-    return ColumnDataSource(d)
+    @convert.register(pd.DataFrame, ColumnDataSource)
+    def columndatasource_to_dataframe(cds, **kwargs):
+        df = cds.to_df()
+        return df[sorted(df.columns)]
+
+
+    @convert.register(ColumnDataSource, pd.DataFrame)
+    def dataframe_to_columndatasource(df, **kwargs):
+        d = ColumnDataSource.from_df(df)
+        if 'index' in d:
+            d.pop('index')
+        return ColumnDataSource(d)


### PR DESCRIPTION
When bokeh is not installed, it would create edges from `pd.DataFrame`
to `type(None)` that were invalid and would raise attribute errors.