### PR TITLE
Fix whitespace column datetime coercion for pandas < 0.17

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,6 @@
 Odo
 ===
- 
+
 |Build Status| |Doc Status|
 
 .. image:: https://binstar.org/blaze/odo/badges/build.svg

--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,6 @@
 Odo
 ===
-
+ 
 |Build Status| |Doc Status|
 
 .. image:: https://binstar.org/blaze/odo/badges/build.svg

--- a/odo/backends/pandas.py
+++ b/odo/backends/pandas.py
@@ -58,19 +58,18 @@ def coerce_datetimes(df):
     dtype: object
     """
 
-    def patched_to_datetime(s):
-        # NOTE: In pandas < 0.17, pd.to_datetime(' ') == datetime(...), which
-        # is not what we want.  This patched version detects empty or
-        # whitespace-only strings, and maps them to a dummy object.  This
-        # prevents datetime coercion on whitespace or empty strings.
-        o = object()
-        s_norm = s.apply(lambda x: o if (hasattr(x, 'strip') and not x.strip()) else x)
-        res = pd.to_datetime(s_norm, errors='ignore')
-        return res.apply(lambda x: '' if x is o else x)
-
-    df2 = df.select_dtypes(include=['object']).apply(patched_to_datetime)
-    for c in df2.columns:
-        df[c] = df2[c]
+    df2 = df.select_dtypes(include=[object])
+    # NOTE: In pandas < 0.17, pd.to_datetime(' ') == datetime(...), which is
+    # not what we want.  So we first remove all columns that have empty or
+    # whitsepace-only strings to compensate.  This prevents datetime coercion
+    # on whitespace or empty strings.
+    empty_or_ws_cols = df2.apply(lambda s: s.str.strip() == '').all()
+    for colname, remove in empty_or_ws_cols.iteritems():
+        if remove:
+            del df2[colname]
+    df3 = df2.apply(partial(pd.to_datetime, errors='ignore'))
+    for c in df3.columns:
+        df[c] = df3[c]
     return df
 
 

--- a/odo/backends/pandas.py
+++ b/odo/backends/pandas.py
@@ -57,9 +57,18 @@ def coerce_datetimes(df):
     name            object
     dtype: object
     """
-    df2 = df.select_dtypes(include=['object']).apply(
-        partial(pd.to_datetime, errors='ignore')
-    )
+
+    def patched_to_datetime(s):
+        # NOTE: In pandas < 0.17, pd.to_datetime(' ') == datetime(...), which
+        # is not what we want.  This patched version detects empty or
+        # whitespace-only strings, and maps them to a dummy object.  This
+        # prevents datetime coercion on whitespace or empty strings.
+        o = object()
+        s_norm = s.apply(lambda x: o if (hasattr(x, 'strip') and not x.strip()) else x)
+        res = pd.to_datetime(s_norm, errors='ignore')
+        return res.apply(lambda x: '' if x is o else x)
+
+    df2 = df.select_dtypes(include=['object']).apply(patched_to_datetime)
     for c in df2.columns:
         df[c] = df2[c]
     return df

--- a/odo/backends/pandas.py
+++ b/odo/backends/pandas.py
@@ -64,9 +64,11 @@ def coerce_datetimes(df):
         # whitespace-only strings, and maps them to a dummy object.  This
         # prevents datetime coercion on whitespace or empty strings.
         o = object()
-        s_norm = s.apply(lambda x: o if (hasattr(x, 'strip') and not x.strip()) else x)
-        res = pd.to_datetime(s_norm, errors='ignore')
-        return res.apply(lambda x: '' if x is o else x)
+        try:
+            s[s.str.strip() == ''] = o
+        except TypeError:
+            pass
+        return pd.to_datetime(s, errors='ignore')
 
     df2 = df.select_dtypes(include=['object']).apply(patched_to_datetime)
     for c in df2.columns:

--- a/odo/backends/tests/test_csv.py
+++ b/odo/backends/tests/test_csv.py
@@ -65,6 +65,13 @@ def test_pandas_read_supports_datetimes():
         assert df.dtypes['when'] == 'M8[ns]'
 
 
+def test_pandas_read_supports_whitespace_strings():
+    with filetext('a,b, \n1,2, \n2,3, \n', extension='csv') as fn:
+        csv = CSV(fn)
+        ds = discover(csv)
+        assert ds == datashape.dshape("var * {a: int64, b: int64, '': ?string}")
+
+
 def test_pandas_read_supports_missing_integers():
     with filetext('Alice,1\nBob,') as fn:
         ds = datashape.dshape('var * {name: string, val: ?int32}')


### PR DESCRIPTION
This patches `pandas.to_datetime()` for pandas < 0.17.  Does not affect things for Pandas == 0.17.

Resolves issue #340.