### PR TITLE
[#343] Add S3 Multipart upload support to aws backend

### DIFF
--- a/odo/backends/aws.py
+++ b/odo/backends/aws.py
@@ -237,12 +237,12 @@ def start_multipart_upload_operation(s3):
 @append.register(S3(JSON), (JSON, Temp(JSON)))
 @append.register(S3(CSV), (CSV, Temp(CSV)))
 @append.register(S3(TextFile), (TextFile, Temp(TextFile)))
-def append_text_to_s3(s3, data, multipart=False, part_size=5 * 1 << 20, **kwargs):
+def append_text_to_s3(s3, data, multipart=False, part_size=5 << 20, **kwargs):
     if multipart:
         with start_multipart_upload_operation(s3) as multipart_upload:
             with open(data.path, 'rb') as f:
-                for part_number, part in enumerate(iter(curry(f.read, part_size), '')):
-                    multipart_upload.upload_part_from_file(BytesIO(part), part_num=part_number + 1)
+                for part_number, part in enumerate(iter(curry(f.read, part_size), ''), start=1):
+                    multipart_upload.upload_part_from_file(BytesIO(part), part_num=part_number)
         return s3
 
     s3.object.set_contents_from_filename(data.path)

--- a/odo/backends/aws.py
+++ b/odo/backends/aws.py
@@ -11,7 +11,7 @@ from operator import attrgetter
 from io import BytesIO
 
 import pandas as pd
-from toolz import memoize, first
+from toolz import memoize, first, curry
 
 from .. import (discover, CSV, resource, append, convert, drop, Temp, JSON,
                 JSONLines, chunks)
@@ -225,7 +225,10 @@ def start_multipart_upload_operation(s3):
     try:
         multipart_upload = s3.object.bucket.initiate_multipart_upload(s3.key)
         yield multipart_upload
-    finally:
+    except Exception as exception:
+        multipart_upload.cancel_multipart_upload()
+        raise exception
+    else:
         multipart_upload.complete_upload()
 
 
@@ -233,33 +236,26 @@ def start_multipart_upload_operation(s3):
 @append.register(S3(JSON), (JSON, Temp(JSON)))
 @append.register(S3(CSV), (CSV, Temp(CSV)))
 @append.register(S3(TextFile), (TextFile, Temp(TextFile)))
-def append_text_to_s3(s3, data, use_s3_multipart_upload=False, **kwargs):
-    if use_s3_multipart_upload:
+def append_text_to_s3(s3, data, multipart=False, **kwargs):
+    if multipart:
         with start_multipart_upload_operation(s3) as multipart_upload:
-            _multipart_upload(data, multipart_upload)
+            _upload(data, multipart_upload, **kwargs)
         return s3
 
     s3.object.set_contents_from_filename(data.path)
     return s3
 
 
-def _multipart_upload(data, multipart_upload):
-    chunk, chunk_bytes, parts_counter = [], 0, 0
+def _upload(data, multipart_upload, part_size=5 * 1 << 20, **kwargs):
+    parts_counter = 0
 
-    def upload_part():
-        part = BytesIO(b"".join(chunk))
-        multipart_upload.upload_part_from_file(part, part_num=parts_counter + 1)
+    def upload_part(part):
+        multipart_upload.upload_part_from_file(BytesIO(part), part_num=parts_counter + 1)
         return parts_counter + 1
 
-    with open(data.path, "rb") as data_file:
-        for line in data_file:
-            chunk.append(line)
-            chunk_bytes += len(line)
-            if chunk_bytes >= 5 * 1024 ** 2:
-                parts_counter = upload_part()
-                chunk, chunk_bytes = [], 0
-
-        upload_part()
+    with open(data.path, 'rb') as f:
+        for part in iter(curry(f.read, part_size), ''):
+            parts_counter = upload_part(part)
 
 
 try:

--- a/odo/backends/tests/test_aws.py
+++ b/odo/backends/tests/test_aws.py
@@ -337,6 +337,6 @@ def test_csv_to_s3__using_multipart_upload():
     with tmpfile('.csv') as fn:
         with s3_bucket('.csv') as b:
             df.to_csv(fn, index=False)
-            s3 = into(b, CSV(fn), use_s3_multipart_upload=True)
+            s3 = into(b, CSV(fn), multipart=True)
             result = into(pd.DataFrame, s3)
     tm.assert_frame_equal(df, result)


### PR DESCRIPTION
- New S3 Multipart integration tests tries to upload 5MB files due to S3 chunk size limitation. As a result, the test are going to get really slow
- Introduced use_s3_multipart_upload flag as kwargs. Another option is to use file size for perhaps more intelligent default behavior.Please let me know what you guys think.

Also consider,
- Using [Moto](https://github.com/spulec/moto) or other Fake S3 libraries for integration tests that can run locally easily
- Using mocks for unittest
- What could be a good approach to handle default S3 chunk size. Currently, it is hard coded at 5MB.
