### PR TITLE
pandas discovery of float

### DIFF
--- a/docs/source/whatsnew/0.4.0.txt
+++ b/docs/source/whatsnew/0.4.0.txt
@@ -43,6 +43,10 @@ API Changes
 
 * Removed support for Python 2.6 (:issue:`333`).
 * Removed support for Python 3.3 (:issue:`335`).
+* ``pandas.DataFrame`` no longer discovers float32 and float64 as option types
+  (:issue:`366`).
+* ``pandas.Series`` now discovers strings and datetimes as option types
+  (:issue:`366`).
 
 Bug Fixes
 ---------

--- a/odo/backends/pandas.py
+++ b/odo/backends/pandas.py
@@ -4,7 +4,7 @@ from datetime import datetime
 from functools import partial
 
 from datashape import discover
-from datashape import float32, float64, string, Option, object_, datetime_
+from datashape import string, object_, datetime_, Option
 import datashape
 
 import pandas as pd
@@ -13,24 +13,25 @@ import numpy as np
 from ..convert import convert
 
 
-possibly_missing = set((string, datetime_, float32, float64))
+possibly_missing = frozenset({string, datetime_})
+
+
+def dshape_from_pandas(dtype):
+    dshape = datashape.CType.from_numpy_dtype(dtype)
+    dshape = string if dshape == object_ else dshape
+    return Option(dshape) if dshape in possibly_missing else dshape
 
 
 @discover.register(pd.DataFrame)
 def discover_dataframe(df):
-    obj = object_
-    names = list(df.columns)
-    dtypes = list(map(datashape.CType.from_numpy_dtype, df.dtypes))
-    dtypes = [string if dt == obj else dt for dt in dtypes]
-    odtypes = [Option(dt) if dt in possibly_missing else dt
-               for dt in dtypes]
-    schema = datashape.Record(list(zip(names, odtypes)))
-    return len(df) * schema
+    return len(df) * datashape.Record(
+        zip(df.columns, map(dshape_from_pandas, df.dtypes)),
+    )
 
 
 @discover.register(pd.Series)
 def discover_series(s):
-    return len(s) * datashape.CType.from_numpy_dtype(s.dtype)
+    return len(s) * dshape_from_pandas(s.dtype)
 
 
 def coerce_datetimes(df):
@@ -57,12 +58,14 @@ def coerce_datetimes(df):
     name            object
     dtype: object
     """
-
     objects = df.select_dtypes(include=['object'])
     # NOTE: In pandas < 0.17, pd.to_datetime(' ') == datetime(...), which is
     # not what we want.  So we have to remove columns with empty or
     # whitespace-only strings to prevent erroneous datetime coercion.
-    columns = [c for c in objects.columns if not np.any(objects[c].str.isspace() | objects[c].str.isalpha())]
+    columns = [
+        c for c in objects.columns
+        if not np.any(objects[c].str.isspace() | objects[c].str.isalpha())
+    ]
     df2 = objects[columns].apply(partial(pd.to_datetime, errors='ignore'))
 
     for c in df2.columns:

--- a/odo/backends/tests/test_aws.py
+++ b/odo/backends/tests/test_aws.py
@@ -16,16 +16,17 @@ import itertools
 import json
 from contextlib import contextmanager, closing
 
+import datashape
+from datashape import string, float64, int64
+from datashape.util.testing import assert_dshape_equal
+import pandas as pd
+import pandas.util.testing as tm
+
 from odo import into, resource, S3, discover, CSV, drop, append, odo
 from odo.backends.aws import get_s3_connection
 from odo.utils import tmpfile
 from odo.compatibility import urlopen
 
-import pandas as pd
-import pandas.util.testing as tm
-
-import datashape
-from datashape import string, float64, int64
 
 from boto.exception import S3ResponseError, NoAuthHandlerFound
 
@@ -300,29 +301,29 @@ def test_s3_jsonlines_discover():
 def test_s3_csv_discover():
     result = discover(resource('s3://nyqpug/tips.csv'))
     expected = datashape.dshape("""var * {
-      total_bill: ?float64,
-      tip: ?float64,
+      total_bill: float64,
+      tip: float64,
       sex: ?string,
       smoker: ?string,
       day: ?string,
       time: ?string,
       size: int64
       }""")
-    assert result == expected
+    assert_dshape_equal(result, expected)
 
 
 def test_s3_gz_csv_discover():
     result = discover(S3(CSV)('s3://nyqpug/tips.gz'))
     expected = datashape.dshape("""var * {
-      total_bill: ?float64,
-      tip: ?float64,
+      total_bill: float64,
+      tip: float64,
       sex: ?string,
       smoker: ?string,
       day: ?string,
       time: ?string,
       size: int64
       }""")
-    assert result == expected
+    assert_dshape_equal(result, expected)
 
 
 def test_s3_to_sqlite():

--- a/odo/backends/tests/test_pandas.py
+++ b/odo/backends/tests/test_pandas.py
@@ -2,8 +2,8 @@ from __future__ import absolute_import, division, print_function
 
 from datetime import datetime
 
-from datashape import discover, Option
-from datashape import dshape
+from datashape import discover, float64, dshape
+from datashape.util.testing import assert_dshape_equal
 from networkx import NetworkXNoPath
 import numpy as np
 import pandas as pd
@@ -28,11 +28,11 @@ def test_discover_series():
     assert discover(s) == 3 * discover(s[0])
 
 
-def test_floats_are_optional():
+def test_floats_are_not_optional():
     df = pd.DataFrame([('Alice', 100), ('Bob', None)],
                       columns=['name', 'amount'])
     ds = discover(df)
-    assert isinstance(ds[1].types[1], Option)
+    assert_dshape_equal(ds[1].types[1], float64)
 
 
 def test_datetime_to_timestamp():

--- a/odo/tests/test_convert.py
+++ b/odo/tests/test_convert.py
@@ -196,7 +196,7 @@ def test_list_of_strings_to_set():
 
 
 def test_datetimes_persist():
-    typs = [list, tuple, pd.Series, np.ndarray, tuple]
+    typs = [list, tuple, np.ndarray, tuple]
     L = [datetime.datetime.now()] * 3
     ds = discover(L)
 


### PR DESCRIPTION
`float` types are not optional in pandas. They are properly modelled in the domain of `float32` or `float64`. Until we have option blocks these should not discover as option types.

Also, if a dataframe column reports that it is optional, discovering just that column should not drop the optionality 