### PR TITLE
Tweak dask backend costs. Add a default chunks size for dask.

### DIFF
--- a/docs/source/releases.rst
+++ b/docs/source/releases.rst
@@ -2,6 +2,9 @@
 Release Notes
 =============
 
+.. include:: whatsnew/0.4.1.txt
+
+.. include:: whatsnew/0.4.0.txt
 
 .. include:: whatsnew/0.3.4.txt
 

--- a/docs/source/whatsnew/0.4.0.txt
+++ b/docs/source/whatsnew/0.4.0.txt
@@ -2,7 +2,7 @@ Release |version|
 -----------------
 
 :Release: |version|
-:Date: TBD
+:Date: December 16th, 2015
 
 New Features
 ------------

--- a/docs/source/whatsnew/0.4.1.txt
+++ b/docs/source/whatsnew/0.4.1.txt
@@ -1,0 +1,11 @@
+Release |version|
+-----------------
+
+:Release: |version|
+:Date: December 17th, 2015
+
+Bug Fixes
+---------
+
+* Tweak dask conversion costs, and give ``array_to_dask`` a default ``chunks``
+  value. This fixes a bug that was holding up the blaze release.

--- a/odo/backends/tests/test_dask_array.py
+++ b/odo/backends/tests/test_dask_array.py
@@ -22,7 +22,7 @@ def eq(a, b):
 
 def test_convert():
     x = np.arange(600).reshape((20, 30))
-    d = convert(Array, x, chunks=(4, 5))
+    d = convert(Array, x)
     assert isinstance(d, Array)
 
 


### PR DESCRIPTION
When odo tries to route through the current dask.array backend it does not set the `chunks` keyword arg, so it fails.

This came up while preparing the blaze release today. 