### PR TITLE
don't use memoized metadata for SqlAlchemy, resolves #380

### DIFF
--- a/odo/backends/sql.py
+++ b/odo/backends/sql.py
@@ -515,7 +515,7 @@ def resource_sql(uri, *args, **kwargs):
     # we were also given a table name
     if args and isinstance(args[0], (str, unicode)):
         table_name, args = args[0], args[1:]
-        metadata = metadata_of_engine(engine, schema=schema)
+        metadata = sa.MetaData(engine, schema=schema)
 
         with ignoring(sa.exc.NoSuchTableError):
             return attach_schema(


### PR DESCRIPTION
issue #380 occurs because the SqlAlchemy metadata for the engine is only retrieved once, due to the memoization of `metadata_of_engine`. Since the engine object isn't changed, the cached metadata is re-used, even though a table has been dropped and the metadata should be different.

In my opinion, it's not safe to memoize the SqlAlchemy metadata in any case. It's not a pure function. It seems like this kind of issue might happen often.