### PR TITLE
Add back `metadata_of_engine()` with deprecation warning.

### DIFF
--- a/odo/backends/sql.py
+++ b/odo/backends/sql.py
@@ -33,7 +33,7 @@ from toolz import (partition_all, keyfilter, memoize, valfilter, identity,
 from toolz.curried import pluck, map
 
 from ..compatibility import unicode
-from ..utils import keywords, ignoring, iter_except, filter_kwargs
+from ..utils import keywords, ignoring, iter_except, filter_kwargs, deprecated
 from ..convert import convert, ooc_types
 from ..append import append
 from ..resource import resource
@@ -206,6 +206,11 @@ def discover_sqlalchemy_selectable(t):
     for name, column in merge(*fkeys).items():
         records[ordering[name]] = (name, column)
     return var * Record(records)
+
+
+@deprecated(replacement=sa.MetaData)
+def metadata_of_engine(engine, schema=None):
+    return sa.MetaData(engine, schema=schema)
 
 
 @dispatch(sa.engine.base.Engine, str)

--- a/odo/utils.py
+++ b/odo/utils.py
@@ -410,29 +410,6 @@ def deprecated(replacement=None):
     """A decorator which can be used to mark functions as deprecated.
     replacement is a callable that will be called with the same args
     as the decorated function.
-    
-    >>> @deprecated()
-    ... def foo(x):
-    ...     return x
-    ...
-    >>> ret = foo(1)
-    DeprecationWarning: foo is deprecated
-    >>> ret
-    1
-    >>>
-    >>>
-    >>> def newfun(x):
-    ...     return 0
-    ...
-    >>> @deprecated(newfun)
-    ... def foo(x):
-    ...     return x
-    ...
-    >>> ret = foo(1)
-    DeprecationWarning: foo is deprecated; use newfun instead
-    >>> ret
-    0
-    >>>
     """
     def outer(fun):
         msg = "{} is deprecated".format(fun.__name__)


### PR DESCRIPTION
This was removed in commit 8e599dc03e, which breaks dependent projects
(like blaze).  Added here with deprecation warning.
`metadata_of_engine()` will be removed entirely after one minor release
cycle.