### PR TITLE
timedelta improvements

### DIFF
--- a/docs/source/whatsnew/0.4.1.txt
+++ b/docs/source/whatsnew/0.4.1.txt
@@ -1,0 +1,45 @@
+Release |version|
+-----------------
+
+:Release: |version|
+:Date: TBD
+
+New Features
+------------
+
+None
+
+Experimental Features
+---------------------
+
+.. warning::
+
+   Experimental features are subject to change.
+
+None
+
+New Backends
+------------
+
+None
+
+Improved Backends
+-----------------
+
+* Sql backend now support coercing to and from :class:`datetime.timedelta`
+  objects (:issue:`394`).
+
+API Changes
+-----------
+
+None
+
+Bug Fixes
+---------
+
+None
+
+Miscellaneous
+-------------
+
+None

--- a/docs/source/whatsnew/0.4.1.txt
+++ b/docs/source/whatsnew/0.4.1.txt
@@ -28,6 +28,9 @@ Improved Backends
 
 * Sql backend now support coercing to and from :class:`datetime.timedelta`
   objects (:issue:`394`).
+* Pandas backend now supports ``timedelta -> pd.TimeDelta``. This includes
+  edges from ``None -> pd.NaT`` and ``NaT`` for ``pd.TimeDelta``
+  (:issue:`394`).
 
 API Changes
 -----------

--- a/odo/backends/pandas.py
+++ b/odo/backends/pandas.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import, division, print_function
 
-from datetime import datetime
+from datetime import datetime, timedelta
 from functools import partial
 
 from datashape import discover
@@ -78,7 +78,7 @@ def convert_datetime_to_timestamp(dt, **kwargs):
     return pd.Timestamp(dt)
 
 
-@convert.register(pd.Timestamp, float)
+@convert.register((pd.Timestamp, pd.Timedelta), float)
 def nan_to_nat(fl, **kwargs):
     try:
         if np.isnan(fl):
@@ -89,6 +89,13 @@ def nan_to_nat(fl, **kwargs):
     raise NotImplementedError()
 
 
-@convert.register(pd.Timestamp, (pd.tslib.NaTType, type(None)))
+@convert.register((pd.Timestamp, pd.Timedelta), (pd.tslib.NaTType, type(None)))
 def convert_null_or_nat_to_nat(n, **kwargs):
     return pd.NaT
+
+
+@convert.register(pd.Timedelta, timedelta)
+def convert_timedelta_to_pd_timedelta(dt, **kwargs):
+    if dt is None:
+        return pd.NaT
+    return pd.Timedelta(dt)

--- a/odo/backends/sql.py
+++ b/odo/backends/sql.py
@@ -9,7 +9,7 @@ import decimal
 from operator import attrgetter
 from itertools import chain
 from collections import Iterator
-from datetime import datetime, date
+from datetime import datetime, date, timedelta
 from distutils.spawn import find_executable
 
 import pandas as pd
@@ -28,8 +28,8 @@ from datashape import discover, datetime_, date_, float64, int64, int_, string
 from datashape import float32
 from datashape.dispatch import dispatch
 
-from toolz import (partition_all, keyfilter, memoize, valfilter, identity,
-                   concat, curry, merge)
+from toolz import (partition_all, keyfilter, valfilter, identity, concat,
+                   curry, merge)
 from toolz.curried import pluck, map
 
 from ..compatibility import unicode
@@ -40,7 +40,7 @@ from ..resource import resource
 from ..chunks import Chunks
 from .csv import CSV
 
-base = int, float, datetime, date, bool, str, decimal.Decimal
+base = int, float, datetime, date, bool, str, decimal.Decimal, timedelta
 
 
 # http://docs.sqlalchemy.org/en/latest/core/types.html

--- a/odo/backends/tests/test_pandas.py
+++ b/odo/backends/tests/test_pandas.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import, division, print_function
 
-from datetime import datetime
+from datetime import datetime, timedelta
 
 from datashape import discover, float64, dshape
 from datashape.util.testing import assert_dshape_equal
@@ -44,16 +44,30 @@ def test_datetime_to_timestamp():
 
 def test_nan_to_nat():
     assert odo(float('nan'), pd.Timestamp) is pd.NaT
+    assert odo(float('nan'), pd.Timedelta) is pd.NaT
     assert odo(np.nan, pd.Timestamp) is pd.NaT
+    assert odo(np.nan, pd.Timedelta) is pd.NaT
 
     with pytest.raises(NetworkXNoPath):
         # Check that only nan can be converted.
         odo(0.5, pd.Timestamp)
 
+    with pytest.raises(NetworkXNoPath):
+        # Check that only nan can be converted.
+        odo(0.5, pd.Timedelta)
+
 
 def test_none_to_nat():
     assert odo(None, pd.Timestamp) is pd.NaT
+    assert odo(None, pd.Timedelta) is pd.NaT
 
 
 def test_nat_to_nat():
     assert odo(pd.NaT, pd.Timestamp) is pd.NaT
+    assert odo(pd.NaT, pd.Timedelta) is pd.NaT
+
+
+def test_timedelta_to_pandas():
+    assert odo(timedelta(days=1), pd.Timedelta) == pd.Timedelta(days=1)
+    assert odo(timedelta(hours=1), pd.Timedelta) == pd.Timedelta(hours=1)
+    assert odo(timedelta(seconds=1), pd.Timedelta) == pd.Timedelta(seconds=1)


### PR DESCRIPTION
I should be able to odo an `interval` into a `timedelta`.'

This also allows me to odo a `timedelta` into a `pd.Timedelta`