### PR TITLE
append empty iter to table bug

### DIFF
--- a/docs/source/whatsnew/0.4.1.txt
+++ b/docs/source/whatsnew/0.4.1.txt
@@ -1,0 +1,46 @@
+Release |version|
+-----------------
+
+:Release: |version|
+:Date: TBD
+
+New Features
+------------
+
+None
+
+Experimental Features
+---------------------
+
+.. warning::
+
+   Experimental features are subject to change.
+
+None
+
+New Backends
+------------
+
+None
+
+Improved Backends
+-----------------
+
+None
+
+API Changes
+-----------
+
+None
+
+Bug Fixes
+---------
+
+* Fixed a bug in :func:`odo.backends.sql.append_iterator_to_table` where
+  ``None`` would be returned if the iterator was empty. This now correctly
+  returns the table (:issue:`395`).
+
+Miscellaneous
+-------------
+
+None

--- a/odo/backends/sql.py
+++ b/odo/backends/sql.py
@@ -410,7 +410,7 @@ def append_iterator_to_table(t, rows, dshape=None, bind=None, **kwargs):
     try:
         row = next(rows)
     except StopIteration:
-        return
+        return t
     rows = chain([row], rows)
     if isinstance(row, (tuple, list)):
         dshape = dshape and datashape.dshape(dshape)

--- a/odo/backends/tests/test_sql.py
+++ b/odo/backends/tests/test_sql.py
@@ -734,3 +734,9 @@ def test_decimal_conversion():
         t = odo(data, 'sqlite:///%s::x' % fn, dshape='var * {x: decimal[11, 2]}')
         result = odo(sa.select([sa.func.sum(t.c.x)]), Decimal)
     assert result == sum(Decimal(r[0]) for r in data)
+
+
+def test_append_empty_iterator_returns_table():
+    with tmpfile('.db') as fn:
+        t = resource('sqlite:///%s::x' % fn, dshape='var * {a: int32}')
+        assert odo(iter([]), t) is t


### PR DESCRIPTION
`odo(it, table)` should return `table` even when `it` is empty