### PR TITLE
Remove spark 1.3

### DIFF
--- a/.binstar.yml
+++ b/.binstar.yml
@@ -8,7 +8,6 @@ platform:
   - win-32
   - win-64
 engine:
-  - python=2.6
   - python=2.7
   - python=3.3
   - python=3.4
@@ -32,15 +31,4 @@ build_targets: conda
 
 notifications:
   email:
-    recipients: ['mrocklin@continuum.io', 'phillip.cloud@continuum.io']
-
----
-platform: win-32
-engine: python=2.6
-env: LC_ALL=en_US.UTF-8 LANG=en_US.UTF-8
-exclude: true
----
-platform: win-64
-engine: python=2.6
-env: LC_ALL=en_US.UTF-8 LANG=en_US.UTF-8
-exclude: true
+    recipients: ['ksmith@continuum.io', 'lransom@continuum.io']

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,6 @@ matrix:
   fast_finish: true
   include:
     - python: 2.7
-      env: SPARK_VERSION=1.3
-    - python: 2.7
       env: SPARK_VERSION=1.4
     - python: 2.7
       env: SPARK_VERSION=1.5

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -16,7 +16,7 @@ requirements:
     - datashape >=0.4.6
     - numpy >=1.7
     - pandas >=0.15.0
-    - toolz >=0.7.2
+    - toolz >=0.7.3
     - multipledispatch >=0.4.7
     - networkx
 
@@ -25,7 +25,7 @@ requirements:
     - datashape >=0.4.6
     - numpy >=1.7
     - pandas >=0.15.0
-    - toolz >=0.7.2
+    - toolz >=0.7.3
     - multipledispatch >=0.4.7
     - networkx
 

--- a/recommended-requirements.txt
+++ b/recommended-requirements.txt
@@ -1,12 +1,12 @@
-datashape >= 0.4.4
+datashape >= 0.4.6
 numpy >= 1.7
 pandas >= 0.15.0
-toolz
+toolz >= 0.7.3
 multipledispatch >= 0.4.7
 networkx
 sqlalchemy >=0.8.0
 h5py
-pymongo >= 2.8
+pymongo >= 2.8, <3
 bcolz
 sas7bdat
 paramiko


### PR DESCRIPTION
Consensus is that Spark 1.3 isn't worth supporting anymore.

In the next release after 0.4.1, we will expand support to include Spark 1.4 through 1.6.