### PR TITLE
Remove support for Spark 1.3.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,6 @@ matrix:
   fast_finish: true
   include:
     - python: 2.7
-      env: SPARK_VERSION=1.3
-    - python: 2.7
       env: SPARK_VERSION=1.4
     - python: 2.7
       env: SPARK_VERSION=1.5

--- a/docs/source/whatsnew/0.4.1.txt
+++ b/docs/source/whatsnew/0.4.1.txt
@@ -47,4 +47,4 @@ Bug Fixes
 Miscellaneous
 -------------
 
-None
+* Removed support for Spark 1.3 (:issue:`400`) based on consensus.


### PR DESCRIPTION
Consensus is that Spark 1.3 is old news.

A future release of odo (after 0.4.1) will expand support to Spark 1.4 through 1.6.