### PR TITLE
Add categorical support for pandas and dask backend

### DIFF
--- a/docs/source/whatsnew/0.5.1.txt
+++ b/docs/source/whatsnew/0.5.1.txt
@@ -1,0 +1,31 @@
+Release |version|
+-----------------
+
+:Release: |version|
+:Date: TBD
+
+New Features
+------------
+
+None
+
+Experimental Features
+---------------------
+
+.. warning::
+
+   Experimental features are subject to change.
+
+None
+
+New Backends
+------------
+
+None
+
+Improved Backends
+-----------------
+
+* Pandas backend now supports discover on categorical dtypes.
+* Added discover support for :class:`dask.dataframe.DataFrame` and
+  :class:`dask.dataframe.Series` objects.

--- a/odo/backends/dask.py
+++ b/odo/backends/dask.py
@@ -4,9 +4,8 @@ from collections import Iterator
 import numpy as np
 import pandas as pd
 from datashape.dispatch import dispatch
-from datashape import from_numpy
+from datashape import from_numpy, var
 
-import dask
 from dask.array.core import Array, from_array
 from dask.bag.core import Bag
 import dask.bag as db
@@ -20,6 +19,12 @@ from ..utils import filter_kwargs
 @discover.register(Array)
 def discover_dask_array(a, **kwargs):
     return from_numpy(a.shape, a.dtype)
+
+
+@discover.register(dd.Series)
+@discover.register(dd.DataFrame)
+def discover_dask_dataframe(df):
+    return var * discover(df.head()).measure
 
 
 arrays = [np.ndarray]

--- a/odo/backends/tests/test_dask_dataframe.py
+++ b/odo/backends/tests/test_dask_dataframe.py
@@ -8,9 +8,9 @@ pytest.importorskip('pandas')
 import pandas as pd
 import pandas.util.testing as tm
 import numpy as np
-import datashape as ds
-
 import dask.dataframe as dd
+from datashape import var, Record, int64, float64, Categorical
+from datashape.util.testing import assert_dshape_equal
 
 from odo import convert, discover
 
@@ -22,10 +22,10 @@ def test_discover():
                        columns=['x', 'y', 'z'])
     df.x = df.x.astype('category')
     ddf = dd.from_pandas(df, npartitions=2)
-    assert discover(ddf) == ds.var * ds.Record([('x', ds.Categorical(['a', 'b', 'c'])),
-                                         ('y', ds.int64),
-                                         ('z', ds.float64)])
-    assert discover(ddf.x) == ds.var * ds.Categorical(['a', 'b', 'c'])
+    assert_dshape_equal(discover(ddf),
+                        var * Record([('x', Categorical(['a', 'b', 'c'])),
+                                            ('y', int64), ('z', float64)]))
+    assert_dshape_equal(discover(ddf.x), var * Categorical(['a', 'b', 'c']))
 
 
 def test_convert():

--- a/odo/backends/tests/test_dask_dataframe.py
+++ b/odo/backends/tests/test_dask_dataframe.py
@@ -8,10 +8,24 @@ pytest.importorskip('pandas')
 import pandas as pd
 import pandas.util.testing as tm
 import numpy as np
+import datashape as ds
 
 import dask.dataframe as dd
 
-from odo import convert
+from odo import convert, discover
+
+
+def test_discover():
+    df = pd.DataFrame({'x': list('a'*5 + 'b'*5 + 'c'*5),
+                       'y': range(15),
+                       'z': list(map(float, range(15)))},
+                       columns=['x', 'y', 'z'])
+    df.x = df.x.astype('category')
+    ddf = dd.from_pandas(df, npartitions=2)
+    assert discover(ddf) == ds.var * ds.Record([('x', ds.Categorical(['a', 'b', 'c'])),
+                                         ('y', ds.int64),
+                                         ('z', ds.float64)])
+    assert discover(ddf.x) == ds.var * ds.Categorical(['a', 'b', 'c'])
 
 
 def test_convert():

--- a/odo/backends/tests/test_pandas.py
+++ b/odo/backends/tests/test_pandas.py
@@ -77,6 +77,6 @@ def test_categorical_pandas():
     df = pd.DataFrame({'x': list('a'*5 + 'b'*5 + 'c'*5),
                        'y': range(15)}, columns=['x', 'y'])
     df.x = df.x.astype('category')
-    assert discover(df) == 15 * Record([('x', Categorical(['a', 'b', 'c'])),
-                                        ('y', int64)])
-    assert discover(df.x) == 15 * Categorical(['a', 'b', 'c'])
+    assert_dshape_equal(discover(df), 15 * Record([('x',
+                        Categorical(['a', 'b', 'c'])), ('y', int64)]))
+    assert_dshape_equal(discover(df.x), 15 * Categorical(['a', 'b', 'c']))

--- a/odo/backends/tests/test_pandas.py
+++ b/odo/backends/tests/test_pandas.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import, division, print_function
 
 from datetime import datetime, timedelta
 
-from datashape import discover, float64, dshape
+from datashape import discover, float64, dshape, Record, Categorical, int64
 from datashape.util.testing import assert_dshape_equal
 from networkx import NetworkXNoPath
 import numpy as np
@@ -71,3 +71,12 @@ def test_timedelta_to_pandas():
     assert odo(timedelta(days=1), pd.Timedelta) == pd.Timedelta(days=1)
     assert odo(timedelta(hours=1), pd.Timedelta) == pd.Timedelta(hours=1)
     assert odo(timedelta(seconds=1), pd.Timedelta) == pd.Timedelta(seconds=1)
+
+
+def test_categorical_pandas():
+    df = pd.DataFrame({'x': list('a'*5 + 'b'*5 + 'c'*5),
+                       'y': range(15)}, columns=['x', 'y'])
+    df.x = df.x.astype('category')
+    assert discover(df) == 15 * Record([('x', Categorical(['a', 'b', 'c'])),
+                                        ('y', int64)])
+    assert discover(df.x) == 15 * Categorical(['a', 'b', 'c'])


### PR DESCRIPTION
Can now discover pandas dataframes with categorical dtype. Also implemented discover for ``dask.dataframe.DataFrame`` and ``dask.dataframe.Series``.