### PR TITLE
Very minor typo fix in ``utils.copydoc``.

### DIFF
--- a/odo/utils.py
+++ b/odo/utils.py
@@ -391,7 +391,7 @@ def filter_kwargs(f, kwargs):
 def copydoc(from_, to):
     """Copies the docstring from one function to another.
 
-    Paramaters
+    Parameters
     ----------
     from_ : any
         The object to copy the docstring from.


### PR DESCRIPTION
"Paramaters" -> "Parameters" so doc formatting tools correctly parse the
docstring.