### PR TITLE
BUG: start memoizing metadata again

### DIFF
--- a/odo/backends/hdfs.py
+++ b/odo/backends/hdfs.py
@@ -17,6 +17,7 @@ from datashape import coretypes as ct
 from collections import namedtuple, Iterator
 from contextlib import contextmanager
 from .ssh import SSH
+from .sql import metadata_of_engine
 from ..utils import tmpfile, sample, ignoring, raises
 from ..temp import Temp
 from ..append import append
@@ -147,7 +148,7 @@ def resource_hive_table(uri, stored_as='TEXTFILE', external=True, dshape=None, *
         dshape = datashape.dshape(dshape)
     uri, table = uri.split('::')
     engine = resource(uri)
-    metadata = sa.MetaData(engine)
+    metadata = metadata_of_engine(engine)
 
     # If table exists then return it
     with ignoring(sa.exc.NoSuchTableError):
@@ -349,7 +350,7 @@ def create_new_hive_table_from_csv(tbl, data, dshape=None, path=None, **kwargs):
     with tbl.engine.connect() as conn:
         conn.execute(statement)
 
-    metadata = sa.MetaData(tbl.engine)
+    metadata = metadata_of_engine(tbl.engine)
     tbl2 = sa.Table(tbl.name, metadata, autoload=True,
             autoload_with=tbl.engine)
     return tbl2
@@ -379,7 +380,7 @@ def append_remote_csv_to_new_table(tbl, data, dshape=None, **kwargs):
     with tbl.engine.connect() as conn:
         conn.execute(statement)
 
-    metadata = sa.MetaData(tbl.engine)
+    metadata = metadata_of_engine(tbl.engine)
     tbl2 = sa.Table(tbl.name, metadata, autoload=True,
             autoload_with=tbl.engine)
 

--- a/odo/backends/tests/test_sql.py
+++ b/odo/backends/tests/test_sql.py
@@ -377,9 +377,8 @@ def test_engine_metadata_caching():
         b = resource(
             'sqlite:///' + fn + '::b', dshape=dshape('var * {y: int}'))
 
-        assert a.metadata is not b.metadata
-        assert engine is not a.bind
-        assert engine is not b.bind
+        assert a.metadata is b.metadata
+        assert engine is a.bind is b.bind
 
 
 def test_copy_one_table_to_a_foreign_engine():

--- a/odo/backends/tests/test_sql.py
+++ b/odo/backends/tests/test_sql.py
@@ -5,20 +5,19 @@ pytest.importorskip('sqlalchemy')
 
 import os
 from decimal import Decimal
+from functools import partial
 
+import datashape
+from datashape import discover, dshape, float32, float64
 import numpy as np
 import pandas as pd
-
 import sqlalchemy as sa
-import toolz as tz
-from datashape import discover, dshape, float32, float64
-import datashape
 
+from odo import convert, append, resource, into, odo, chunks
 from odo.backends.sql import (
     dshape_to_table, create_from_datashape, dshape_to_alchemy
 )
 from odo.utils import tmpfile, raises
-from odo import convert, append, resource, discover, into, odo, chunks
 
 
 def test_resource():
@@ -739,3 +738,22 @@ def test_append_empty_iterator_returns_table():
     with tmpfile('.db') as fn:
         t = resource('sqlite:///%s::x' % fn, dshape='var * {a: int32}')
         assert odo(iter([]), t) is t
+
+
+def test_pass_non_hashable_arg_to_create_engine():
+    with tmpfile('.db') as fn:
+        r = partial(
+            resource,
+            'sqlite:///%s::t' % fn,
+            connect_args={},
+            dshape='var * {a: int32}',
+        )
+        assert r() is r()
+
+    s = partial(
+        resource,
+        'sqlite:///:memory:::t',
+        connect_args={},
+        dshape='var * {a: int32}',
+    )
+    assert s() is not s()


### PR DESCRIPTION
We are leaking a lot of connections right now which is causing me to hit connection limits. 

This change addresses the bugs that we fixed in #328 by using a frozenset to pass the dict to `create_engine`. We also fix the issue with `drop` by explicitly removing the table from the metadata.

@cpcloud 