### PR TITLE
Regex dispatcher docs

### DIFF
--- a/docs/source/whatsnew/0.4.1.txt
+++ b/docs/source/whatsnew/0.4.1.txt
@@ -48,3 +48,6 @@ Miscellaneous
 -------------
 
 * Removed support for Spark 1.3 (:issue:`400`) based on consensus.
+* Compile the regex patterns once when adding to a
+  :class:`~odo.regex.RegexDispatcher` instead of calling :func:`re.match` with
+  strings (:issue:`413`).

--- a/odo/backends/pandas.py
+++ b/odo/backends/pandas.py
@@ -14,10 +14,11 @@ from ..convert import convert
 
 
 possibly_missing = frozenset({string, datetime_})
+categorical = type(pd.Categorical.dtype)
 
 
 def dshape_from_pandas(col):
-    if isinstance(col.dtype, pd.core.dtypes.CategoricalDtype):
+    if isinstance(col.dtype, categorical):
         return Categorical(col.cat.categories.tolist())
     dshape = datashape.CType.from_numpy_dtype(col.dtype)
     dshape = string if dshape == object_ else dshape

--- a/odo/regex.py
+++ b/odo/regex.py
@@ -31,26 +31,26 @@ class RegexDispatcher(object):
 
     >>> f = RegexDispatcher('f')
 
-    >>> f.register('\d*')               # doctest: +SKIP
+    >>> f.register('\d*')
     ... def parse_int(s):
     ...     return int(s)
 
-    >>> f.register('\d*\.\d*')          # doctest: +SKIP
+    >>> f.register('\d*\.\d*')
     ... def parse_float(s):
     ...     return float(s)
 
     Set priorities to break ties between multiple matches.
     Default priority is set to 10
 
-    >>> f.register('\w*', priority=9)   # doctest: +SKIP
+    >>> f.register('\w*', priority=9)
     ... def parse_str(s):
     ...     return s
 
-    >>> f('123')                        # doctest: +SKIP
-    123
+    >>> type(f('123'))
+    int
 
-    >>> f('123.456')                    # doctest: +SKIP
-    123.456
+    >>> type(f('123.456'))
+    float
     """
     def __init__(self, name):
         self.name = name
@@ -62,6 +62,22 @@ class RegexDispatcher(object):
         self.priorities[func] = priority
 
     def register(self, regex, priority=10):
+        """Register a new handler in this regex dispatcher.
+
+        Parameters
+        ----------
+        regex : str or Pattern
+            The pattern to match against.
+        priority : int, optional
+            The priority for this pattern. This is used to resolve ambigious
+            matches. The highest priority match wins.
+
+        Returns
+        -------
+        decorator : callable
+            A decorator that registers the function with this RegexDispatcher
+            but otherwise returns the function unchanged.
+        """
         def _(func):
             self.add(regex, func, priority)
             return func
@@ -76,4 +92,5 @@ class RegexDispatcher(object):
 
     @property
     def __doc__(self):
+        # take the min to give the docstring of the last fallback function
         return min(self.priorities.items(), key=lambda x: x[1])[0].__doc__

--- a/odo/tests/test_regex.py
+++ b/odo/tests/test_regex.py
@@ -1,22 +1,24 @@
 from __future__ import absolute_import, division, print_function
 
 from odo.regex import RegexDispatcher
+
 import re
+
 
 def test_regex_dispatcher():
     foo = RegexDispatcher('foo')
 
-    @foo.register('\d*', priority=9)
+    @foo.register(r'\d*', priority=9)
     def a(s):
         """ A's docstring """
         return int(s)
 
-    @foo.register('\D*')
+    @foo.register(re.compile(r'\D*'))
     def b(s):
         """ B's docstring """
         return s
 
-    @foo.register('0\d*', priority=11)
+    @foo.register(r'0\d*', priority=11)
     def c(s):
         """ C's docstring """
         return s


### PR DESCRIPTION
Fixes the categorical check on older versions of pandas.

Adds docstrings as requested in: #412 
Compiles the patterns once.