### PR TITLE
BUG: This get's MSSQL server working...

### DIFF
--- a/odo/backends/sql.py
+++ b/odo/backends/sql.py
@@ -18,6 +18,7 @@ from sqlalchemy import inspect
 from sqlalchemy.ext.compiler import compiles
 from sqlalchemy import event
 from sqlalchemy.schema import CreateSchema
+from sqlalchemy.dialects import mssql
 
 from multipledispatch import MDNotImplementedError
 
@@ -84,6 +85,11 @@ revtypes.update({
     sa.Float: float64,
     sa.Float(precision=24): float32,
     sa.Float(precision=53): float64,
+    mssql.BIT: datashape.bool_,
+    mssql.DATETIMEOFFSET: string,
+    mssql.MONEY: float64,
+    mssql.SMALLMONEY: float32,
+    mssql.UNIQUEIDENTIFIER: string
 })
 
 # interval types are special cased in discover_typeengine so remove them from
@@ -172,7 +178,7 @@ def discover_typeengine(typ):
     if isinstance(typ, (sa.NUMERIC, sa.DECIMAL)):
         return datashape.Decimal(precision=typ.precision, scale=typ.scale)
     if isinstance(typ, (sa.String, sa.Unicode)):
-        return datashape.String(typ.length, typ.collation)
+        return datashape.String(typ.length, 'U8')
     else:
         for k, v in revtypes.items():
             if isinstance(k, type) and (isinstance(typ, k) or

--- a/odo/backends/tests/test_sql.py
+++ b/odo/backends/tests/test_sql.py
@@ -281,19 +281,19 @@ def test_discover_oracle_intervals(freq):
 def test_mssql_types():
     typ = sa.dialects.mssql.BIT()
     t = sa.Table('t', sa.MetaData(), sa.Column('bit', typ))
-    assert discover(t) == dshape('var * {bit: ?bool}')
+    assert_dshape_equal(discover(t), dshape('var * {bit: ?bool}'))
     typ = sa.dialects.mssql.DATETIMEOFFSET()
     t = sa.Table('t', sa.MetaData(), sa.Column('dt', typ))
-    assert discover(t) == dshape('var * {dt: ?string}')
+    assert_dshape_equal(discover(t), dshape('var * {dt: ?string}'))
     typ = sa.dialects.mssql.MONEY()
     t = sa.Table('t', sa.MetaData(), sa.Column('money', typ))
-    assert discover(t) == dshape('var * {money: ?float64}')
+    assert_dshape_equal(discover(t), dshape('var * {money: ?float64}'))
     typ = sa.dialects.mssql.SMALLMONEY()
     t = sa.Table('t', sa.MetaData(), sa.Column('money', typ))
-    assert discover(t) == dshape('var * {money: ?float32}')
+    assert_dshape_equal(discover(t), dshape('var * {money: ?float32}'))
     typ = sa.dialects.mssql.UNIQUEIDENTIFIER()
     t = sa.Table('t', sa.MetaData(), sa.Column('uuid', typ))
-    assert discover(t) == dshape('var * {uuid: ?string}')
+    assert_dshape_equal(discover(t), dshape('var * {uuid: ?string}'))
 
 
 def test_create_from_datashape():

--- a/odo/backends/tests/test_sql.py
+++ b/odo/backends/tests/test_sql.py
@@ -278,6 +278,24 @@ def test_discover_oracle_intervals(freq):
     assert discover(t) == dshape('var * {dur: ?timedelta[unit="%s"]}' % freq)
 
 
+def test_mssql_types():
+    typ = sa.dialects.mssql.BIT()
+    t = sa.Table('t', sa.MetaData(), sa.Column('bit', typ))
+    assert discover(t) == dshape('var * {bit: ?bool}')
+    typ = sa.dialects.mssql.DATETIMEOFFSET()
+    t = sa.Table('t', sa.MetaData(), sa.Column('dt', typ))
+    assert discover(t) == dshape('var * {dt: ?string}')
+    typ = sa.dialects.mssql.MONEY()
+    t = sa.Table('t', sa.MetaData(), sa.Column('money', typ))
+    assert discover(t) == dshape('var * {money: ?float64}')
+    typ = sa.dialects.mssql.SMALLMONEY()
+    t = sa.Table('t', sa.MetaData(), sa.Column('money', typ))
+    assert discover(t) == dshape('var * {money: ?float32}')
+    typ = sa.dialects.mssql.UNIQUEIDENTIFIER()
+    t = sa.Table('t', sa.MetaData(), sa.Column('uuid', typ))
+    assert discover(t) == dshape('var * {uuid: ?string}')
+
+
 def test_create_from_datashape():
     engine = sa.create_engine('sqlite:///:memory:')
     ds = dshape('''{bank: var * {name: string, amount: int},


### PR DESCRIPTION
Hello,

I wanted to show you what I did to get Blaze working with MSSQL. 

A few points...
* I'm not sure why, but you have a call to `typ.collation` and have that set the encoding of the field. I'm confused by the logic behind this fiend. 
* MSSQL has a few unique datatypes. Chief among them (from my perspective), is BIT. I just hard-added it to the SQL. I admit this is not ideal, and am open to discussing other ways to make it work. I don't know what the correct practice is. 

Once I did this, I could run... 
```
import blaze as bz
import odo
a = bz.Data(odo.resource('mssql+pyodbc://MyDSN::TableName',schema='dbo'))
a.Field.sum()
```

Small complaint... I get a an sqlaclchemy warning... 

```
C:\Anaconda3\lib\site-packages\sqlalchemy\dialects\mssql\base.py:1170: SAWarning: legacy_schema_aliasing flag is defaulted to True; some schema-qualified queries may not function correctly. Consider setting this flag to False for modern SQL Server versions; this flag will default to False in version 1.1
  "legacy_schema_aliasing flag is def
```

Anyone have an idea how to silence this? I tried a few things and couldn't figure it out. 

Thanks for reviewing. I'm happy to amend this to make it fit with your programming practices, but just wanted to show you what worked. 