### PR TITLE
bump datashape version to >=0.5.0, see #437

### DIFF
--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -22,7 +22,7 @@ requirements:
 
   run:
     - python
-    - datashape >=0.4.6
+    - datashape >=0.5.0
     - numpy >=1.7
     - pandas >=0.15.0
     - toolz >=0.7.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-datashape >= 0.4.6
+datashape >= 0.5.0
 numpy >= 1.7
 pandas >= 0.15.0
 toolz >= 0.7.3


### PR DESCRIPTION
Python 3.5 support required changes to `datashape` that were released with version `0.5.0`. Update packaging files to ensure that version of `datashape` gets installed with `odo`. Closes #437.
