### PR TITLE
postgresql COPY FROM can handle with \n , \r, \n\r too

### DIFF
--- a/odo/backends/sql_csv.py
+++ b/odo/backends/sql_csv.py
@@ -147,10 +147,6 @@ def compile_from_csv_postgres(element, compiler, **kwargs):
             'postgres does not allow escape characters longer than 1 byte when '
             'bulk loading a CSV file'
         )
-    if element.lineterminator != '\n':
-        raise ValueError(
-            r'PostgreSQL does not support line terminators other than \n'
-        )
     return compiler.process(
         sa.text(
             """


### PR DESCRIPTION
See #403. Odo throws a `ValueError` when importing a CSV file with windows style line terminators into PostgreSQL (with error message: `"PostgreSQL does not support line terminators other than \n"`).

These tests fail too.
- odo/backends/tests/test_postgres.py::test_complex_into[True] FAILED
- odo/backends/tests/test_postgres.py::test_complex_into[False] FAILED

However, PostgreSQL docs mention _COPY FROM's documentation, "COPY FROM can handle lines ending with newlines, carriage returns, or carriage return/newlines."_
- http://www.postgresql.org/docs/9.4/static/sql-copy.html
- http://www.postgresql.org/docs/9.5/static/sql-copy.html

This PR removes the above mentioned check. 2 tests pass on windows machine.
