### PR TITLE
Allow aws profiles

### DIFF
--- a/odo/backends/aws.py
+++ b/odo/backends/aws.py
@@ -27,8 +27,12 @@ from ..utils import tmpfile, ext, sample, filter_kwargs, copydoc
 @memoize
 def get_s3_connection(aws_access_key_id=None,
                       aws_secret_access_key=None,
-                      anon=False):
+                      anon=False, **kwargs):
     import boto
+
+    if 'profile_name' in kwargs:
+        return boto.connect_s3(profile_name=kwargs['profile_name'])
+
     cfg = boto.Config()
 
     if aws_access_key_id is None:
@@ -70,7 +74,8 @@ class _S3(object):
             self.s3 = s3
         else:
             self.s3 = get_s3_connection(aws_access_key_id=aws_access_key_id,
-                                        aws_secret_access_key=aws_secret_access_key)
+                                        aws_secret_access_key=aws_secret_access_key,
+                                        **kwargs)
         try:
             bucket = self.s3.get_bucket(self.bucket,
                                         **filter_kwargs(self.s3.get_bucket,
@@ -154,7 +159,7 @@ def resource_s3_csv(uri, **kwargs):
 
 @resource.register('s3://.*\*.csv(\.gz)?', priority=19)
 def resource_s3_csv_glob(uri, **kwargs):
-    con = get_s3_connection()
+    con = get_s3_connection(**kwargs)
     result = urlparse(uri)
     bucket = con.get_bucket(result.netloc, validate=False)
     key = result.path.lstrip('/')

--- a/odo/backends/aws.py
+++ b/odo/backends/aws.py
@@ -25,13 +25,12 @@ from ..utils import tmpfile, ext, sample, filter_kwargs, copydoc
 
 
 @memoize
-def get_s3_connection(aws_access_key_id=None,
-                      aws_secret_access_key=None,
-                      anon=False, **kwargs):
+def get_s3_connection(aws_access_key_id=None, aws_secret_access_key=None,
+                      anon=False, profile_name=None, **kwargs):
     import boto
 
-    if 'profile_name' in kwargs:
-        return boto.connect_s3(profile_name=kwargs['profile_name'])
+    if profile_name:
+        return boto.connect_s3(profile_name=profile_name)
 
     cfg = boto.Config()
 


### PR DESCRIPTION
Allow `profile_name` for getting s3 client. This allows respecting of things like `~/.aws/credentials` so you can have multiple profiles and don't have to munge environment variables or parse the config file yourself.

I also caught another `get_bucket` without `validate=False`.
