### PR TITLE
implemented ElasticSearch backend

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -58,7 +58,6 @@ install:
   # Install various deps
   - conda uninstall toolz
   - pip install -U toolz sas7bdat psycopg2 dill 'pymongo<3' 'elasticsearch>=2.0.0,<3.0.0' 'elasticsearch-dsl>=2.0.0,<3.0.0'
-  - pip install -U toolz sas7bdat psycopg2 dill 'pymongo<3'
   - pip install git+git://github.com/blaze/dask.git#egg=dask-dev[complete]
   - if [ -n "$PANDAS_VERSION" ]; then pip install $PANDAS_VERSION; fi
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -57,7 +57,7 @@ install:
 
   # Install various deps
   - conda uninstall toolz
-  - pip install -U toolz sas7bdat psycopg2 dill 'pymongo<3'
+  - pip install -U toolz sas7bdat psycopg2 dill 'pymongo<3' 'elasticsearch>=2.0.0,<3.0.0' 'elasticsearch-dsl>=2.0.0,<3.0.0'
   - pip install --upgrade git+git://github.com/blaze/dask.git#egg=dask-dev[complete]
   - if [ -n "$PANDAS_VERSION" ]; then pip install $PANDAS_VERSION; fi
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,6 +36,9 @@ services:
     - mongodb
     - mysql
 
+before_install:
+  - curl -O https://download.elasticsearch.org/elasticsearch/elasticsearch/elasticsearch-2.3.4.deb && sudo dpkg -i --force-confnew elasticsearch-2.3.4.deb && sudo service elasticsearch restart
+
 install:
   # Install conda
   - wget http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,9 +35,7 @@ addons:
 services:
     - mongodb
     - mysql
-
-before_install:
-  - curl -O https://download.elasticsearch.org/elasticsearch/elasticsearch/elasticsearch-2.3.4.deb && sudo dpkg -i --force-confnew elasticsearch-2.3.4.deb && sudo service elasticsearch restart
+    - elasticsesarch
 
 install:
   # Install conda

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ addons:
 services:
     - mongodb
     - mysql
-    - elasticsesarch
+    - elasticsearch
 
 install:
   # Install conda

--- a/extra-requirements.txt
+++ b/extra-requirements.txt
@@ -6,5 +6,5 @@ sas7bdat
 paramiko
 pywebhdfs
 boto
-elasticsearch > 2
-elasticsearch-dsl > 2
+elasticsearch>=2.0.0,<3.0.0
+elasticsearch-dsl>=2.0.0,<3.0.0

--- a/extra-requirements.txt
+++ b/extra-requirements.txt
@@ -6,3 +6,5 @@ sas7bdat
 paramiko
 pywebhdfs
 boto
+elasticsearch > 2
+elasticsearch-dsl > 2

--- a/odo/__init__.py
+++ b/odo/__init__.py
@@ -63,6 +63,8 @@ with ignoring(ImportError):
     from .backends.url import URL
 with ignoring(ImportError):
     from .backends.dask import dask
+with ignoring(ImportError):
+    from .backends.elasticsearch import elasticsearch
 
 
 restart_ordering()  # Restart multipledispatch ordering and do ordering

--- a/odo/backends/elasticsearch.py
+++ b/odo/backends/elasticsearch.py
@@ -1,0 +1,168 @@
+from __future__ import absolute_import, division, print_function
+
+import json
+import re
+import warnings
+from collections import Iterator
+
+import elasticsearch
+from datashape import Record, var, isdimension
+from datashape.discovery import discover
+from datashape.dispatch import dispatch
+from elasticsearch import helpers
+from elasticsearch_dsl import Index, Search
+from elasticsearch_dsl.query import MatchAll
+from odo import convert
+from odo.core import ooc_types
+from toolz import concat, pluck, take
+
+from ..append import append
+from ..resource import resource
+
+
+class DocumentCollection(Index):
+    """
+    Parametrized ElasticSearch Index
+    """
+
+    def __init__(self, name, doc_type, using='default'):
+        super(DocumentCollection, self).__init__(name=name, using=using)
+        self._doc_type = doc_type
+
+    def search(self):
+        return Search(
+            using=self._using,
+            index=self._name,
+            doc_type=self._doc_type
+        )
+
+    def delete(self, **kwargs):
+        warnings.warn('Deletion of specific document type is unsupported from ES 2.x, dropping the whole index')
+        super(DocumentCollection, self).delete(**kwargs)
+
+    def __repr__(self):
+        host = self.connection.transport.hosts[0]
+        return '<DocumentCollection on {host}:{port} - {index}/{doctype}>'.format(
+            host=host['host'], port=host['port'], index=self._doc_type, doctype=self._name)
+
+    def bulk_insert(self, documents_iter, chunksize=1024):
+        bulk_iter = ({'_type': self._doc_type, '_index': self._name, '_source': json.dumps(d)} for d in documents_iter)
+        helpers.bulk(self.connection, bulk_iter, chunk_size=chunksize)
+
+    def head(self, n):
+        """
+        Returns the first n docuemnts in this collection.
+
+        Parameters
+        ----------
+        n: int
+            Number of results to fetch
+
+        Returns
+        -------
+        List of results
+        """
+        return list(take(n, iter(self)))
+
+    def __iter__(self):
+        return self.search().query(MatchAll()).scan()
+
+
+@discover.register(DocumentCollection)
+def discover_elasticsearch_index(collection, n=10):
+    """
+    Parameters
+    ----------
+    collection : DocumentCollection
+    n: int
+        Number of results to check for shape consistency
+    """
+    items = collection.head(n)
+    items = list(map(es_result_to_dict, items))
+
+    if not items:
+        return var * Record([])
+
+    ds = discover(items)
+    if isdimension(ds[0]):
+        return collection.search().count() * ds.subshape[0]
+    else:
+        raise ValueError("Consistent datashape not found")
+
+
+@convert.register(Iterator, DocumentCollection, cost=500.0)
+def index_to_iterator(collection, columns=None, dshape=None, **kwargs):
+    seq = map(es_result_to_dict, collection)
+    if not columns and dshape:
+        columns = dshape.measure.names
+    elif not columns:
+        item = next(seq)
+        seq = concat([[item], seq])
+        columns = sorted(item.keys())
+
+    return pluck(columns, seq)
+
+
+def es_result_to_dict(result):
+    return result.__dict__['_d_']
+
+
+@append.register(DocumentCollection, Iterator)
+def append_seq_to_index(collection, seq, columns=None, dshape=None, chunksize=1024, **kwargs):
+    seq = iter(seq)
+    peek = next(seq)
+
+    # reconstruct
+    seq = concat([[peek], seq])
+
+    if isinstance(peek, (tuple, list)):
+        if not columns and dshape:
+            columns = dshape.measure.names
+        if not columns:
+            raise ValueError("Inputs must be dictionaries. "
+                             "Or provide columns=[...] or dshape=DataShape(...) keyword")
+        seq = (dict(zip(columns, item)) for item in seq)
+
+    collection.bulk_insert(seq, chunksize=chunksize)
+
+    return collection
+
+
+@append.register(DocumentCollection, object)
+def append_anything_to_index(index, o, **kwargs):
+    return append(index, convert(Iterator, o, **kwargs), **kwargs)
+
+
+@resource.register(r'elasticsearch://\w*:\w*@\w*.*', priority=11)
+def resource_elasticsearch_with_authentication(uri, doctype=None, **kwargs):
+    pattern = r'elasticsearch://(?P<user>\w*):(?P<pass>\w*)@(?P<hostport>.*:?\d*)/(?P<index>\w+)'
+    d = re.search(pattern, uri).groupdict()
+    return _resource_elasticsearch(d, doctype)
+
+
+@resource.register(r'elasticsearch://.+')
+def resource_elasticsearch(uri, doctype=None, **kwargs):
+    pattern = r'elasticsearch://(?P<hostport>.*:?\d*)/(?P<index>\w+)'
+    d = re.search(pattern, uri).groupdict()
+    return _resource_elasticsearch(d, doctype)
+
+
+def _resource_elasticsearch(conn_info_dict, doctype):
+    auth_info = None
+    if conn_info_dict.get('user'):  # need to authenticate
+        auth_info = (conn_info_dict['user'], conn_info_dict['pass'])
+
+    client = elasticsearch.Elasticsearch(hosts=[conn_info_dict['hostport']], http_auth=auth_info)
+
+    # noinspection PyTypeChecker
+    collection = DocumentCollection(conn_info_dict.get('index'), doc_type=doctype, using=client)
+
+    return collection
+
+
+ooc_types.add(DocumentCollection)
+
+
+@dispatch(DocumentCollection)
+def drop(i):
+    i.delete()

--- a/odo/backends/elasticsearch.py
+++ b/odo/backends/elasticsearch.py
@@ -1,6 +1,5 @@
 from __future__ import absolute_import, division, print_function
 
-import json
 import re
 from collections import Iterator
 
@@ -60,7 +59,7 @@ class DocumentCollection(Index):
             host=host['host'], port=host['port'], index=self._doc_type, doctype=self._name)
 
     def bulk_insert(self, documents_iter, chunksize=1024):
-        bulk_iter = ({'_type': self._doc_type, '_index': self._name, '_source': json.dumps(d)} for d in documents_iter)
+        bulk_iter = ({'_type': self._doc_type, '_index': self._name, '_source': d} for d in documents_iter)
         helpers.bulk(self.connection, bulk_iter, chunk_size=chunksize)
 
     def head(self, n):
@@ -162,6 +161,7 @@ def resource_elasticsearch(uri, doctype=None, **kwargs):
 
 
 def _resource_elasticsearch(conn_info_dict, doctype):
+    assert doctype, 'Using the elasticsearch backend without a doctype is not supported!'
     auth_info = None
     if conn_info_dict.get('user'):  # need to authenticate
         auth_info = (conn_info_dict['user'], conn_info_dict['pass'])

--- a/odo/backends/elasticsearch.py
+++ b/odo/backends/elasticsearch.py
@@ -148,14 +148,14 @@ def append_anything_to_index(index, o, **kwargs):
 
 @resource.register(r'elasticsearch://\w*:\w*@\w*.*', priority=11)
 def resource_elasticsearch_with_authentication(uri, doctype=None, **kwargs):
-    pattern = r'elasticsearch://(?P<user>\w*):(?P<pass>\w*)@(?P<hostport>.*:?\d*)/(?P<index>\w+)'
+    pattern = r'elasticsearch://(?P<user>\w*):(?P<pass>\w*)@(?P<hostport>.*:?\d*)/(?P<index>[\w\.\-\_]+'
     d = re.search(pattern, uri).groupdict()
     return _resource_elasticsearch(d, doctype)
 
 
 @resource.register(r'elasticsearch://.+')
 def resource_elasticsearch(uri, doctype=None, **kwargs):
-    pattern = r'elasticsearch://(?P<hostport>.*:?\d*)/(?P<index>\w+)'
+    pattern = r'elasticsearch://(?P<hostport>.*:?\d*)/(?P<index>[\w\.\-\_]+)'
     d = re.search(pattern, uri).groupdict()
     return _resource_elasticsearch(d, doctype)
 

--- a/odo/backends/tests/test_elasticsearch.py
+++ b/odo/backends/tests/test_elasticsearch.py
@@ -1,0 +1,105 @@
+import time
+
+import pytest
+from bson import ObjectId
+from datashape import dshape
+from odo import convert
+from odo import odo, resource, discover, append
+from odo.backends.elasticsearch import DocumentCollection
+from toolz import pluck
+
+# elasticsearch is eventually consistent
+# so a small sleep is required to make the documents available.
+SMALL_SLEEP_UNTIL_DOCUMENTS_AVAILABLE_FOR_QUERYING = 2
+
+es = pytest.importorskip('elasticsearch')
+elasticsearch_dsl = pytest.importorskip('elasticsearch_dsl')
+
+
+@pytest.fixture(scope='module')
+def elastic_host_port():
+    import os
+    return (os.environ.get('ELASTICSEARCH_IP', 'localhost'),
+            os.environ.get('ELASTICSEARCH_PORT', 9200))
+
+
+@pytest.fixture(scope='module')
+def conn(elastic_host_port):
+    host, port = elastic_host_port
+    try:
+        return es.Elasticsearch(hosts=['{}:{}'.format(host, port)])
+    except es.ElasticsearchException:
+        pytest.skip('No elasticsearch server running')
+
+
+@pytest.yield_fixture
+def doc_collection(conn):
+    dc = DocumentCollection(name='test_', doc_type='bank', using=conn)
+    try:
+        dc.create()
+        yield dc
+    except es.ElasticSearchException:
+        dc.delete()
+        yield dc
+    finally:
+        dc.delete()
+
+
+@pytest.yield_fixture
+def empty_bank(conn):
+    dc = DocumentCollection(name='test_empty_', doc_type='bank', using=conn)
+    try:
+        dc.create()
+        yield dc
+    finally:
+        dc.delete()
+
+
+@pytest.fixture
+def raw_bank():
+    return [
+        {'name': 'Alice', 'amount': 100},
+        {'name': 'Alice', 'amount': 200},
+        {'name': 'Bob', 'amount': 100},
+        {'name': 'Bob', 'amount': 200},
+        {'name': 'Bob', 'amount': 300}
+    ]
+
+
+@pytest.yield_fixture
+def bank(doc_collection, raw_bank):
+    try:
+        doc_collection.bulk_insert(raw_bank)
+        time.sleep(SMALL_SLEEP_UNTIL_DOCUMENTS_AVAILABLE_FOR_QUERYING)
+        yield doc_collection
+    finally:
+        print('Collection will be dropped with entire index')
+        pass
+
+
+ds = dshape('var * {name: string, amount: int}')
+
+
+def test_resource_collection(elastic_host_port):
+    host, port = elastic_host_port
+    coll = resource('elasticsearch://{}:{}/index::test_docs'.format(host, port))
+    assert coll._doc_type == 'test_docs'
+    elastic_host = coll.connection.transport.hosts[0]
+    assert elastic_host['host'] == host
+    assert elastic_host['port'] == port
+
+
+def test_discover(bank, raw_bank):
+    assert discover(bank) == discover(raw_bank)
+
+
+def test_append_convert(empty_bank, raw_bank):
+    ds = discover(raw_bank)
+    assert set(ds.measure.names) == {'name', 'amount'}
+
+    append(empty_bank, raw_bank, dshape=ds)
+    time.sleep(SMALL_SLEEP_UNTIL_DOCUMENTS_AVAILABLE_FOR_QUERYING)
+    assert set(odo(empty_bank, list, dshape=ds)) == set(list(
+        pluck(ds.measure.names, raw_bank)
+    ))
+

--- a/odo/backends/tests/test_elasticsearch.py
+++ b/odo/backends/tests/test_elasticsearch.py
@@ -32,25 +32,28 @@ def conn(elastic_host_port):
 
 @pytest.yield_fixture
 def doc_collection(conn):
-    dc = DocumentCollection(name='test_', doc_type='bank', using=conn)
+    dc = DocumentCollection(index_name='test_', doc_type='bank', using=conn)
     try:
         dc.create()
         yield dc
-    except es.ElasticSearchException:
-        dc.delete()
+    except es.ElasticsearchException:
+        dc.delete_index()
         yield dc
     finally:
-        dc.delete()
+        dc.delete_index()
 
 
 @pytest.yield_fixture
 def empty_bank(conn):
-    dc = DocumentCollection(name='test_empty_', doc_type='bank', using=conn)
+    dc = DocumentCollection(index_name='test_empty_', doc_type='bank', using=conn)
     try:
         dc.create()
         yield dc
+    except es.ElasticsearchException:
+        dc.delete_index()
+        yield dc
     finally:
-        dc.delete()
+        dc.delete_index()
 
 
 @pytest.fixture
@@ -71,8 +74,8 @@ def bank(doc_collection, raw_bank):
         time.sleep(SMALL_SLEEP_UNTIL_DOCUMENTS_AVAILABLE_FOR_QUERYING)
         yield doc_collection
     finally:
-        print('Collection will be dropped with entire index')
-        pass
+        doc_collection.delete()
+        time.sleep(SMALL_SLEEP_UNTIL_DOCUMENTS_AVAILABLE_FOR_QUERYING)
 
 
 ds = dshape('var * {name: string, amount: int}')

--- a/odo/backends/tests/test_elasticsearch.py
+++ b/odo/backends/tests/test_elasticsearch.py
@@ -1,9 +1,7 @@
 import time
 
 import pytest
-from bson import ObjectId
 from datashape import dshape
-from odo import convert
 from odo import odo, resource, discover, append
 from odo.backends.elasticsearch import DocumentCollection
 from toolz import pluck
@@ -102,4 +100,3 @@ def test_append_convert(empty_bank, raw_bank):
     assert set(odo(empty_bank, list, dshape=ds)) == set(list(
         pluck(ds.measure.names, raw_bank)
     ))
-


### PR DESCRIPTION
Hi,

I've implemented a backend for ElasticSearch to use with odo.
I've drawn some inspiration from the existing mongodb backend.

Elasticsearch doesn't currently provide a primitive similar to mongo collection, so I've implemented DocumentCollection, which is essentially a filtered index with a specific doctype (so the datashape is consistent).

One thing I haven't implemented is [nested documents](https://www.elastic.co/guide/en/elasticsearch/guide/current/nested-objects.html). 

I'd love to hear what you think.
Cheers!
