### PR TITLE
Pass kwargs to S3 append_text_to_s3 functions

### DIFF
--- a/odo/backends/tests/test_s3.py
+++ b/odo/backends/tests/test_s3.py
@@ -93,34 +93,34 @@ test_bucket_name = 'into-redshift-csvs'
 _tmps = ('tmp%d' % i for i in itertools.count())
 
 
-def test_s3_encrypted_upload():
+@pytest.fixture
+def s3_encryption_bucket():
     test_bucket = os.getenv('ODO_S3_ENCRYPTION_BUCKET')
     if not test_bucket:
         pytest.skip('No bucket defined that requires server-side encryption')
+    return test_bucket
 
+
+def test_s3_encrypted_upload(s3_encryption_bucket):
     s3_connection = boto.connect_s3()
 
     df = tm.makeMixedDataFrame()
     with tmpfile('.csv') as fn:
         df.to_csv(fn, index=False)
-        s3_uri = 's3://{bucket}/{fn}'.format(bucket=test_bucket, fn=os.path.basename(fn))
+        s3_uri = 's3://{bucket}/{fn}'.format(bucket=s3_encryption_bucket, fn=os.path.basename(fn))
         odo(fn, s3_uri, s3=s3_connection, encrypt_key=True)
         result = odo(s3_uri, pd.DataFrame, s3=s3_connection)
 
     tm.assert_frame_equal(df, result)
 
 
-def test_s3_encrypted_multipart_upload():
-    test_bucket = os.getenv('ODO_S3_ENCRYPTION_BUCKET')
-    if not test_bucket:
-        pytest.skip('No bucket defined that requires server-side encryption')
-
+def test_s3_encrypted_multipart_upload(s3_encryption_bucket):
     s3_connection = boto.connect_s3()
 
     df = tm.makeMixedDataFrame()
     with tmpfile('.csv') as fn:
         df.to_csv(fn, index=False)
-        s3_uri = 's3://{bucket}/{fn}'.format(bucket=test_bucket, fn=os.path.basename(fn))
+        s3_uri = 's3://{bucket}/{fn}'.format(bucket=s3_encryption_bucket, fn=os.path.basename(fn))
         odo(fn, s3_uri, s3=s3_connection, encrypt_key=True, multipart=True)
         result = odo(s3_uri, pd.DataFrame, s3=s3_connection)
 


### PR DESCRIPTION
- This allows encrypt_key=True to be passed to the relevant boto functions,
  which is required if the S3 bucket requires server-side encrpytion.

I wrote two new tests to test this functionality, but to test it properly, you need an S3 bucket with a policy that will only accept puts with server-side encryption. So as not to break CI, I configured this so that the tests will run if the ODO_S3_ENCRYPTION_BUCKET environment variable is set. This environment variable should contain the name of a bucket that has this policy.

I tested this locally and the tests fail without this patch and pass with the patch. If there's a solid way to always have a bucket with this policy on hand for the tests, it can be made non-optional, otherwise I'm comfortable that this resolves #166.