### PR TITLE
Issue #465: Fix datashape discovery if dshape=None.

### DIFF
--- a/odo/core.py
+++ b/odo/core.py
@@ -50,7 +50,7 @@ def _transform(graph, target, source, excluded_edges=None, ooc_types=ooc_types,
     x = source
     excluded_edges = excluded_edges or set()
     with ignoring(NotImplementedError):
-        if 'dshape' not in kwargs:
+        if 'dshape' not in kwargs or kwargs['dshape'] is None:
             kwargs['dshape'] = discover(x)
     pth = path(graph, type(source), target,
                excluded_edges=excluded_edges,

--- a/odo/tests/test_convert.py
+++ b/odo/tests/test_convert.py
@@ -285,3 +285,18 @@ def test_ndarray_to_df_preserves_field_names():
     assert (convert(pd.DataFrame, arr, dshape=ds).columns == ['a', 'b']).all()
     # no dshape is passed.
     assert (convert(pd.DataFrame, arr).columns == [0, 1]).all()
+
+
+def test_iterator_to_df():
+    ds = dshape('var * int32')
+    it = iter([1, 2, 3])
+    df = convert(pd.DataFrame, it, dshape=ds)
+    assert df[0].tolist() == [1, 2, 3]
+
+    it = iter([1, 2, 3])
+    df = convert(pd.DataFrame, it, dshape=None)
+    assert df[0].tolist() == [1, 2, 3]
+
+    it = iter([1, 2, 3])
+    df = convert(pd.DataFrame, it)
+    assert df[0].tolist() == [1, 2, 3]


### PR DESCRIPTION
@kwmsmith This fixes #465.  If you have time to merge this, it might be easier to finish work on https://github.com/blaze/blaze/pull/1559 .