### PR TITLE
Remove build directory in the travis builds.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -82,6 +82,7 @@ before_script:
 
 script:
   - conda list numpy
+  - rm -rf build
   - py.test -v --doctest-modules --doctest-ignore-import-errors odo
 
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -82,7 +82,7 @@ before_script:
 
 script:
   - conda list numpy
-  - rm -rf build
+  - git clean -f -x
   - py.test -v --doctest-modules --doctest-ignore-import-errors odo
 
 notifications:


### PR DESCRIPTION
The build failures occur whenever there's a leftover build directory.  Let's see if this fixes it.