### PR TITLE
S3(x) to x directly gets object from S3

### DIFF
--- a/odo/backends/aws.py
+++ b/odo/backends/aws.py
@@ -211,7 +211,8 @@ def s3_text_to_temp_text(s3_object, **kwargs):
 @append.register(JSONLines, S3(JSONLines))
 @append.register(TextFile, S3(TextFile))
 def s3_text_to_text(data, s3_object, **kwargs):
-    return append(data, convert(Temp(s3_object.subtype), s3_object, **kwargs), **kwargs)
+    s3_object.object.get_contents_to_filename(data.path)
+    return data
 
 
 @append.register((S3(CSV), Temp(S3(CSV))), (S3(CSV), Temp(S3(CSV))))

--- a/odo/backends/tests/test_s3.py
+++ b/odo/backends/tests/test_s3.py
@@ -25,7 +25,7 @@ from odo.utils import tmpfile
 from odo.compatibility import urlopen
 
 
-from boto.exception import S3ResponseError, NoAuthHandlerFound
+from boto.exception import S3ResponseError
 
 tips_uri = 's3://nyqpug/tips.csv'
 


### PR DESCRIPTION
It used to route through a Temp(*) object unnecessarily.
Also removed an unneeded import from the S3 tests.

Resolves #472.