### PR TITLE
Handle low-precision Decimal data shapes

### DIFF
--- a/docs/source/whatsnew/0.5.1.txt
+++ b/docs/source/whatsnew/0.5.1.txt
@@ -40,6 +40,7 @@ Bug Fixes
 * Adds workaround to skip ssh tests on Py2 due to paramiko hang (:issue:`474`).
 * Fixes issue with kwarg passing for S3 backend (:issue:`466`).
 * S3(x) to x directly gets object from S3 (:issue:`472` :issue:`473`).
+* Correctly handles low-precision decimal fields (:issue:`479`).
 
 Miscellaneous
 -------------

--- a/odo/numpy_dtype.py
+++ b/odo/numpy_dtype.py
@@ -37,9 +37,10 @@ def unit_to_dtype(ds):
         ds = ds.measure
     if isinstance(ds, Option) and isscalar(ds) and isnumeric(ds):
         if isinstance(ds.ty, Decimal):
-            return unit_to_dtype(
-                str(ds.ty.to_numpy_dtype()).replace('int', 'float')
-            )
+            str_np_dtype = str(ds.ty.to_numpy_dtype()).replace('int', 'float')
+            if str_np_dtype == 'float8':  # not a valid dtype, so increase
+                str_np_dtype = 'float16'
+            return unit_to_dtype(str_np_dtype)
         return unit_to_dtype(str(ds).replace('int', 'float').replace('?', ''))
     if isinstance(ds, Option) and isinstance(
         ds.ty, (Date, DateTime, String, TimeDelta)

--- a/odo/tests/test_numpy_dtype.py
+++ b/odo/tests/test_numpy_dtype.py
@@ -13,6 +13,7 @@ import numpy as np
         ('decimal[9,2]', np.float64),
         ('decimal[9]', np.int32),
         ('?decimal[9]', np.float32),
+        ('?decimal[1,0]', np.float16),
     ]
 )
 def test_decimal(ds, expected):


### PR DESCRIPTION
Optional decimals with suitably low precision (i.e. `?decimal[precision<=2]` are translated as `float8` which is not a valid datashape (or NumPy datatype) -- we need to handle that case.
