### PR TITLE
Fix sqlite CSV import command.

### DIFF
--- a/odo/backends/sql_csv.py
+++ b/odo/backends/sql_csv.py
@@ -85,11 +85,11 @@ def compile_from_csv_sqlite(element, compiler, **kwargs):
     cmd = ['sqlite3',
            '-nullvalue', repr(element.na_value),
            '-separator', element.delimiter,
-           '-cmd', '.import "%s" %s' % (
+           element.bind.url.database,
+           '.import "%s" %s' % (
                # FIXME: format_table(t) is correct, but sqlite will complain
                fullpath, compiler.preparer.format_table(t)
-           ),
-           element.bind.url.database]
+           )]
     stderr = subprocess.check_output(
         cmd,
         stderr=subprocess.STDOUT,


### PR DESCRIPTION
Current sqlite3 binaries do not take a -cmd option. They use positional
arguments instead. This fixes the problem for CSV import.