### PR TITLE
ENH: clean up the dtypes in the postgres select->dataframe edge

### DIFF
--- a/odo/backends/tests/test_postgres.py
+++ b/odo/backends/tests/test_postgres.py
@@ -333,5 +333,5 @@ def test_to_dataframe(sql):
 
     df = odo(sql, pd.DataFrame, bind=bind)
     expected = pd.DataFrame(np.array([(1, 2), (3, 4)],
-                                     dtype=[('a', 'int32'), ('b', 'float32')]))
+                                     dtype=[('a', 'int32'), ('b', 'float64')]))
     pd.util.testing.assert_frame_equal(df, expected)


### PR DESCRIPTION
dataframe return dtype was not totally correct. Also allows us to discover column clauses, not just columns.
