### PR TITLE
Add dask as hard requirement

### DIFF
--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -19,6 +19,7 @@ requirements:
     - toolz >=0.7.3
     - multipledispatch >=0.4.7
     - networkx
+    - dask >=0.11.1
 
   run:
     - python
@@ -28,6 +29,7 @@ requirements:
     - toolz >=0.7.3
     - multipledispatch >=0.4.7
     - networkx
+    - dask >=0.11.1
 
 test:
   requires:

--- a/etc/requirements.txt
+++ b/etc/requirements.txt
@@ -4,3 +4,4 @@ pandas >= 0.15.0
 toolz >= 0.7.3
 multipledispatch >= 0.4.7
 networkx >= 1.0
+dask >= 0.11.1

--- a/etc/requirements_dask.txt
+++ b/etc/requirements_dask.txt
@@ -1,1 +1,0 @@
-dask[complete]>=0.11.1

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,6 @@ def extras_require():
                           'bcolz',
                           'bokeh',
                           'ci',
-                          'dask',
                           'h5py',
                           'mongo',
                           'mysql',


### PR DESCRIPTION
With the work on the `chunks` backend merged in #481 , `dask` becomes a hard requirement.

@llllllllll would appreciate a sanity check on this ASAP so I can tag `0.5.2` and build packages; this is a prerequisite for a similar tag-and-update need on Blaze.