### PR TITLE
Fix convert a directory of files

### DIFF
--- a/odo/core.py
+++ b/odo/core.py
@@ -158,6 +158,12 @@ def path(graph, source, target, excluded_edges=None, ooc_types=ooc_types):
                 source = cls
                 break
 
+    # For Directory class we need its container type to find the path in the graph
+    from odo.chunks import chunks
+    from odo.directory import _Directory
+    if issubclass(source, _Directory):
+        source = chunks(source.container)
+
     # If both source and target are Out-Of-Core types then restrict ourselves
     # to the graph of out-of-core types
     if ooc_types:


### PR DESCRIPTION
This PR Addresses #151.

Basically, the bug happens as the the dynamically generated parameterized Directory class is not found in the graph in NetworkDispatcher. A conversion path should be identified by the parameterized Chunks superclass.

I still need to add test cases so that this bug will not reappear, but where is best place for me to add the test cases?