### PR TITLE
search through the entire mro of the source type in NetworkDispatcher

### DIFF
--- a/docs/source/whatsnew/0.6.0.txt
+++ b/docs/source/whatsnew/0.6.0.txt
@@ -12,6 +12,10 @@ New Features
   current value to the target. This can prevent a lot of duplicated work when
   the new path shares a prefix with the original path (:issue:`449`).
 
+* ``convert`` will now search the entire mro of the source type. This means that
+  you can convert a subclass of a known source type into a known destination
+  type (:issue:`518`).
+
 Experimental Features
 ---------------------
 

--- a/odo/backends/tests/test_csv.py
+++ b/odo/backends/tests/test_csv.py
@@ -478,3 +478,18 @@ def test_globbed_csv_to_chunks_of_dataframe():
                           pd.DataFrame([[1, 2, 3], [4, 5, 6]], columns=columns))
     tm.assert_frame_equal(dfs[1],
                           pd.DataFrame([[7, 8, 9], [10, 11, 12]], columns=columns))
+
+
+def test_globbed_csv_to_dataframe():
+    header = 'a,b,c\n'
+    d = {'a-1.csv': header + '1,2,3\n4,5,6\n',
+         'a-2.csv': header + '7,8,9\n10,11,12\n'}
+
+    with filetexts(d):
+        df = odo('a-*.csv', pd.DataFrame)
+
+    tm.assert_frame_equal(
+        df,
+        pd.DataFrame([[1, 2, 3], [4, 5, 6], [7, 8, 9], [10, 11, 12]],
+                     columns=['a', 'b', 'c']),
+    )

--- a/odo/core.py
+++ b/odo/core.py
@@ -1,11 +1,13 @@
 from __future__ import absolute_import, division, print_function
 
-from collections import namedtuple
+from collections import namedtuple, Iterator
 from contextlib import contextmanager
 from warnings import warn
 
 from datashape import discover
 import networkx as nx
+import numpy as np
+from toolz import concatv
 
 from .compatibility import map
 from .utils import expand_tuples, ignoring
@@ -143,6 +145,7 @@ def _transform(graph, target, source, excluded_edges=None, ooc_types=ooc_types,
 
 
 PathPart = namedtuple('PathPart', 'convert_from convert_to func cost')
+_virtual_superclasses = (Iterator,)
 
 
 def path(graph, source, target, excluded_edges=None, ooc_types=ooc_types):
@@ -152,11 +155,10 @@ def path(graph, source, target, excluded_edges=None, ooc_types=ooc_types):
     if not isinstance(target, type):
         target = type(target)
 
-    if source not in graph:
-        for cls in valid_subclasses:
-            if issubclass(source, cls):
-                source = cls
-                break
+    for cls in concatv(source.mro(), _virtual_superclasses):
+        if cls in graph:
+            source = cls
+            break
 
     # If both source and target are Out-Of-Core types then restrict ourselves
     # to the graph of out-of-core types
@@ -180,12 +182,6 @@ def path_cost(path):
     """Calculate the total cost of a path.
     """
     return sum(p.cost for p in path)
-
-
-# Catch-all subclasses
-from collections import Iterator
-import numpy as np
-valid_subclasses = [Iterator, np.ndarray]
 
 
 @contextmanager

--- a/odo/directory.py
+++ b/odo/directory.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import, division, print_function
 
 from glob import glob
-from .chunks import Chunks
+from .chunks import Chunks, chunks
 from .resource import resource
 from .utils import copydoc
 from toolz import memoize, first
@@ -38,7 +38,7 @@ class _Directory(Chunks):
 @copydoc(_Directory)
 def Directory(cls):
     """ Parametrized DirectoryClass """
-    return type('Directory(%s)' % cls.__name__, (_Directory,), {'container': cls})
+    return type('Directory(%s)' % cls.__name__, (_Directory, chunks(cls)), {})
 
 
 re_path_sep = os.path.sep


### PR DESCRIPTION
supersedes #516

This generalizes the work in #516 to work for any subclass, not just `_Directory`