### PR TITLE
Fix for #515 switch to Numeric type

### DIFF
--- a/odo/backends/sql.py
+++ b/odo/backends/sql.py
@@ -184,7 +184,7 @@ def discover_typeengine(typ):
         return dshape(revtypes[typ])[0]
     if type(typ) in revtypes:
         return revtypes[type(typ)]
-    if isinstance(typ, (sa.NUMERIC, sa.DECIMAL)):
+    if isinstance(typ, sa.Numeric):
         return datashape.Decimal(precision=typ.precision, scale=typ.scale)
     if isinstance(typ, (sa.String, sa.Unicode)):
         return datashape.String(typ.length, 'U8')


### PR DESCRIPTION
There are some other types that could be changed though it would mean changing the way we do the lookup.  Plus some things like `FLOAT` are children of `Numeric`.  Not sure how we want to procede here. 

```
In [4]: sa.DECIMAL.mro()
Out[4]:
[sqlalchemy.sql.sqltypes.DECIMAL,
 sqlalchemy.sql.sqltypes.Numeric,
 sqlalchemy.sql.sqltypes._DateAffinity,
 sqlalchemy.sql.type_api.TypeEngine,
 sqlalchemy.sql.visitors.Visitable,
 object]

In [5]: isinstance(sa.DECIMAL(), sa.Numeric)
Out[5]: True

In [6]: sa.DATETIME.mro()
Out[6]:
[sqlalchemy.sql.sqltypes.DATETIME,
 sqlalchemy.sql.sqltypes.DateTime,
 sqlalchemy.sql.sqltypes._DateAffinity,
 sqlalchemy.sql.type_api.TypeEngine,
 sqlalchemy.sql.visitors.Visitable,
 object]

In [7]: sa.TIMESTAMP.mro()
Out[7]:
[sqlalchemy.sql.sqltypes.TIMESTAMP,
 sqlalchemy.sql.sqltypes.DateTime,
 sqlalchemy.sql.sqltypes._DateAffinity,
 sqlalchemy.sql.type_api.TypeEngine,
 sqlalchemy.sql.visitors.Visitable,
 object]

In [2]: sa.Float.mro()
Out[2]:
[sqlalchemy.sql.sqltypes.Float,
 sqlalchemy.sql.sqltypes.Numeric,
 sqlalchemy.sql.sqltypes._DateAffinity,
 sqlalchemy.sql.type_api.TypeEngine,
 sqlalchemy.sql.visitors.Visitable,
 object]
```

Maybe we just want to add more types to `revtypes` so we support more types and maybe a better explanation in the NotImplementedError so they know where to look for supported types.