### PR TITLE
BUG: fix problematic string in postgres->dataframe

### DIFF
--- a/odo/backends/tests/test_postgres.py
+++ b/odo/backends/tests/test_postgres.py
@@ -383,17 +383,44 @@ def test_to_dataframe_strings(sql_with_strings):
     sql_with_strings, bind = sql_with_strings
 
     insert_query = sql_with_strings.insert().values([
-        {'non_optional': 'ayy', 'optional': 'hello "world"'},
-        {'non_optional': 'lmao', 'optional': None},
+        # quoting is done correctly
+        {'non_optional': 'hello "world"', 'optional': 'hello "world"'},
+
+        # None stays None
+        {'non_optional': 'ayy lmao', 'optional': None},
+
+        # nan string is just the string nan
+        {'non_optional': 'nan', 'optional': 'nan'},
+
+        # NULL is just the string NULL
+        {'non_optional': 'NULL', 'optional': 'NULL'},
+
+        # escaping is done correctly
+        {'non_optional': r'\no\t \ \escaped \"',
+         'optional': r'\no\t \ \escaped \"'},
+
+        # empty string is not NULL
+        {'non_optional': '', 'optional': ''},
+
+        # commas are properly escaped
+        {'non_optional': 'comma,delim', 'optional': 'comma,delim'},
     ])
     if bind is None:
         insert_query.execute()
     else:
         bind.execute(insert_query)
 
+    expected = pd.DataFrame(
+        [['hello "world"', 'hello "world"'],
+         ['ayy lmao', None],
+         ['nan', 'nan'],
+         ['NULL', 'NULL'],
+         [r'\no\t \ \escaped \"', r'\no\t \ \escaped \"'],
+         ['', ''],
+         ['comma,delim', 'comma,delim']],
+        columns=['non_optional', 'optional'],
+    )
     df = odo(sql_with_strings, pd.DataFrame, bind=bind)
-    expected = pd.DataFrame([['ayy', 'hello "world"'], ['lmao', None]],
-                            columns=['non_optional', 'optional'])
     pd.util.testing.assert_frame_equal(df, expected)
 
 

--- a/odo/utils.py
+++ b/odo/utils.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import, division, print_function
 
+import codecs
 import warnings
 import functools
 import inspect
@@ -19,7 +20,7 @@ from datashape.discovery import is_zero_time
 
 from toolz import pluck, get, curry, keyfilter
 
-from .compatibility import unicode
+from .compatibility import unicode, PY2
 
 sample = Dispatcher('sample')
 


### PR DESCRIPTION
the string `nan` would be returned as a float object. This preserves all string values. This also ensures quote characters and escapes are passed through correctly.