### PR TITLE
TST: Add appveyor testing

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,69 @@
+skip_tags: true
+clone_depth: 50
+
+os: Visual Studio 2015
+
+environment:
+  matrix:
+    # - PY_MAJOR_VER: 2
+    #   PYTHON_ARCH: "x86_64"
+    - PY_MAJOR_VER: 3
+      PYTHON_ARCH: "x86_64"
+
+platform:
+    - x64
+
+services:
+  # - mssql2014 # No tests for mssql written yet
+  # - mysql # mysql tests fail. Don't understand how to fix at the moment.
+  - postgresql93
+  # - mongodb # mongodb tests fail. Don't understand how to fix at the moment.
+
+build_script:
+  - ps: Start-FileDownload "https://repo.continuum.io/miniconda/Miniconda$env:PY_MAJOR_VER-latest-Windows-$env:PYTHON_ARCH.exe" C:\Miniconda.exe; echo "Finished downloading miniconda"
+  - cmd: C:\Miniconda.exe /S /D=C:\Py
+  - SET PATH=C:\Py;C:\Py\Scripts;C:\Py\Library\bin;%PATH%
+  - conda config --set always_yes yes
+  - conda update conda --quiet
+  - conda create -n odo python=3.5 numpy cryptography pytables h5py pandas dask boto3 bcolz psycopg2 botocore s3transfer pymysql pytest pytz requests s3fs sas7bdat SQLAlchemy pytables odo
+  - activate odo
+  - conda update setuptools pip
+
+  # sqlite
+  - ps: Start-FileDownload "https://sqlite.org/2016/sqlite-tools-win32-x86-3150200.zip" C:\sqlite.zip; echo "Finished downloading sqlite3"
+  - 7z e C:\sqlite.zip
+
+  # mongodb
+  # mongodb tests run, but they fail. Appveyor has more recent version than
+  # travis. For now, don't run tests, and don't set up mongodb.
+  # - SET PATH=C:\mongodb\bin;%PATH%
+  # - ps: 'mongo admin --eval "db.runCommand({setParameter: 1, textSearchEnabled: true});"'
+
+  # MySql
+  # Can't seem to get mysql tests to run properly either. 
+  # - SET PATH=C:\Program Files\MySql\MySQL Server 5.7\bin\;%PATH%
+  # - mysql -u root -p"Password12!" -e "CREATE DATABASE IF NOT EXISTS test;"
+  # - mysql -u root -p"Password12!" -e "CREATE USER 'appveyor'@'localhost';"
+  # - mysql -u root -p"Password12!" -e "GRANT ALL PRIVILEGES ON *.* TO 'appveyor'@'localhost';"
+
+  # Postgresql
+  - SET PGUSER=postgres
+  - SET PGPASSWORD=Password12!
+  - SET PATH=C:\Program Files\PostgreSQL\9.3\bin\;%PATH%
+  - createdb test
+
+  # install the frozen ci dependencies
+  # This takes too long and there's a bunch of dependencies to solve (e.g., h5py) 
+  # - pip install -e .[ci]
+
+  # datashape
+  - pip install git+git://github.com/blaze/datashape.git
+
+  # redshift sqlalchemy dialect
+  - pip install --upgrade git+git://github.com/graingert/redshift_sqlalchemy
+
+  - python setup.py develop
+
+test_script:
+  - conda list
+  - py.test -v --doctest-modules --doctest-ignore-import-errors -rs odo


### PR DESCRIPTION
Hello,

xref #522 

I've put together appveyor.yml for this. 

A few limitations:

* The point of this is to write some mssql tests. Haven't started that yet. 
* I can't get mongodb or mysql to work on appveyor. Going to confess I don't know that much about them however. I can start the service and add them to PATH, but that's about the limit of what I can figure out. 
* I can't successfully run `pip install -e .[ci]`. There's a lot that needs to build and it takes a long, long time and some of it (h5py and cryptography especially) just doesn't cooperate. So instead I just pull the pre-compiled binaries from `conda`. 

Here's the test result of this:

https://ci.appveyor.com/project/thequackdaddy/odo

Let me know if there's interest for this. 

Thanks. 