### PR TITLE
ENH: MSSQL tests/support

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,7 +15,6 @@ platform:
     - x64
 
 services:
-  # - mssql2014 # No tests for mssql written yet
   # - mysql # mysql tests fail. Don't understand how to fix at the moment.
   - postgresql93
   - mongodb
@@ -51,6 +50,14 @@ build_script:
 
   # install python stuff
   - sh etc\ci-install.sh
+
+  # MSSQL
+  # pymssql requires TCP/IP
+  - SET INSTANCENAME=SQL2014
+  - net start MSSQL$%INSTANCENAME%
+  - "powershell ci\\sql_server_tcpip.ps1"
+  - sqlcmd -E -Q "CREATE DATABASE test;"
+
 
 test_script:
   - activate odo

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -50,6 +50,8 @@ build_script:
 
   # install python stuff
   - sh etc\ci-install.sh
+  - conda install cython
+  - pip install git+https://github.com/pymssql/pymssql/
 
   # MSSQL
   # pymssql requires TCP/IP
@@ -58,7 +60,5 @@ build_script:
   - "powershell ci\\sql_server_tcpip.ps1"
   - sqlcmd -E -Q "CREATE DATABASE test;"
 
-
 test_script:
-  - activate odo
   - py.test -v --doctest-modules --doctest-ignore-import-errors -rs odo

--- a/ci/sql_server_tcpip.ps1
+++ b/ci/sql_server_tcpip.ps1
@@ -1,0 +1,20 @@
+[reflection.assembly]::LoadWithPartialName("Microsoft.SqlServer.Smo") | Out-Null
+[reflection.assembly]::LoadWithPartialName("Microsoft.SqlServer.SqlWmiManagement") | Out-Null
+
+$serverName = $env:COMPUTERNAME
+$instanceName = $env:INSTANCENAME
+$smo = 'Microsoft.SqlServer.Management.Smo.'
+$wmi = new-object ($smo + 'Wmi.ManagedComputer')
+
+# Enable TCP/IP
+$uri = "ManagedComputer[@Name='$serverName']/ServerInstance[@Name='$instanceName']/ServerProtocol[@Name='Tcp']"
+$Tcp = $wmi.GetSmoObject($uri)
+$Tcp.IsEnabled = $true
+foreach ($ipAddress in $Tcp.IPAddresses)
+{
+    $ipAddress.IPAddressProperties["TcpDynamicPorts"].Value = ""
+    $ipAddress.IPAddressProperties["TcpPort"].Value = "1433"
+}
+$Tcp.alter()
+
+Restart-Service "MSSQL`$$instanceName"

--- a/odo/backends/sql.py
+++ b/odo/backends/sql.py
@@ -440,16 +440,17 @@ def dshape_to_table(name, ds, metadata=None, foreign_keys=None,
 
     validate_foreign_keys(ds, foreign_keys)
 
-    if (metadata.bind.dialect.name == 'mssql') and metadata.schema:
-        engine = metadata.bind
+    if hasattr(metadata.bind, 'dialect'):
+        if (metadata.bind.dialect.name == 'mssql') and metadata.schema:
+            engine = metadata.bind
 
-        schema_exists = engine.execute(sa.text(
-            """select * from information_schema.schemata where
-            schema_name = :schema"""
-        ).bindparams(schema=metadata.schema)).scalar()
-        if not schema_exists:
-            from sqlalchemy.schema import CreateSchema
-            engine.execute(CreateSchema(metadata.schema))
+            schema_exists = engine.execute(sa.text(
+                """select * from information_schema.schemata where
+                schema_name = :schema"""
+            ).bindparams(schema=metadata.schema)).scalar()
+            if not schema_exists:
+                from sqlalchemy.schema import CreateSchema
+                engine.execute(CreateSchema(metadata.schema))
 
     cols = dshape_to_alchemy(ds, primary_key=primary_key or frozenset())
     cols.extend(sa.ForeignKeyConstraint([column_name], [referent])
@@ -984,7 +985,83 @@ def compile_copy_to_csv_sqlite(element, compiler, **kwargs):
 
 @compiles(CopyToCSV, 'mssql')
 def compile_copy_to_csv_mssql(element, compiler, **kwargs):
-    raise MDNotImplementedError("MSSQL does not have a T-SQL bulk export")
+    if not find_executable('bcp'):
+        raise MDNotImplementedError("Could not find bcp executable")
+
+    # we are sending a SQL string directorly to the SQLite process so we always
+    # need to bind everything before sending it
+    kwargs['literal_binds'] = True
+
+    selectable = element.element
+    sql = compiler.process(
+        selectable.select() if isinstance(selectable, sa.Table) else selectable,
+        **kwargs
+    ) + ';'
+
+
+    fullpath = os.path.abspath(element.path)
+    url = element.bind.url
+
+    sql = re.sub(r'\s{2,}', ' ', re.sub(r'\s*\n\s*', ' ', sql))
+    sql = '"{}"'.format(sql) #  .encode(sys.getfilesystemencoding())
+    
+    cmd = ['bcp.exe',
+           sql,
+           'queryout', fullpath,
+           '-d{}'.format(url.database),
+           '-S{}'.format(url.host),
+           '-t{}'.format(element.delimiter),
+           '-c']
+
+    if url.username:
+        cmd = cmd + ['-U', url.username]
+    else:
+        cmd = cmd + ['-T']
+    if url.password:
+        cmd = cmd + ['-P', url.password]
+
+    cmd = ' '.join(cmd)
+
+    stderr = subprocess.check_output(cmd,
+                                     stderr=subprocess.STDOUT,
+                                     stdin=subprocess.PIPE,
+                                     )
+    if element.header is not False:
+        with CSVPrepender(fullpath) as f:
+            f.write_line(','.join(element.element.columns.keys()))
+    # This will be a no-op since we're doing the write during the compile
+    return ''
+
+    
+# From http://stackoverflow.com/questions/2677617/python-f-write-at-beginning-of-file
+class CSVPrepender(object):
+    def __init__(self, file_path):
+        # Read in the existing file, so we can write it back later
+        with open(file_path, mode='r') as f:
+            self.__write_queue = f.readlines()
+
+        self.__open_file = open(file_path, mode='w')
+
+    def write_line(self, line):
+        self.__write_queue.insert(0,
+                                  "%s\n" % line,
+                                 )
+
+    def write_lines(self, lines):
+        lines.reverse()
+        for line in lines:
+            self.write_line(line)
+
+    def close(self):
+        self.__exit__(None, None, None)
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, type, value, traceback):
+        if self.__write_queue:
+            self.__open_file.writelines(self.__write_queue)
+        self.__open_file.close()
 
 try:
     from sqlalchemy_redshift.dialect import UnloadFromSelect

--- a/odo/backends/sql.py
+++ b/odo/backends/sql.py
@@ -213,7 +213,6 @@ def batch(sel, chunksize=10000, bind=None):
     iterator = rowiterator(sel)
     return columns, concat(iterator)
 
-
 @discover.register(sa.dialects.postgresql.base.INTERVAL)
 def discover_postgresql_interval(t):
     return discover(sa.Interval(day_precision=0, second_precision=t.precision))

--- a/odo/backends/sql_csv.py
+++ b/odo/backends/sql_csv.py
@@ -211,6 +211,29 @@ else:
         return compiler.process(cmd)
 
 
+@compiles(CopyFromCSV, 'mssql')
+def compile_from_csv_mssql(element, compiler, **kwargs):
+    return compiler.process(
+        sa.text(
+            """BULK INSERT {table} FROM '{path}'
+            WITH (
+            FIELDTERMINATOR = '{delimiter}'
+            , ROWTERMINATOR = '{rowterminator}'
+           , FIRSTROW = {firstrow}
+            )
+            """.format(
+                table=compiler.preparer.format_table(element.element),
+                delimiter=element.delimiter,
+                path=os.path.abspath(element.csv.path),
+                rowterminator=element.lineterminator,
+                fieldquote=element.quotechar,
+                firstrow=str(int(element.skiprows) + 1)
+            )
+        ),
+        **kwargs
+    )
+
+
 @append.register(sa.Table, CSV)
 def append_csv_to_sql_table(tbl, csv, bind=None, **kwargs):
     bind = getbind(tbl, bind)
@@ -292,6 +315,8 @@ def append_dataframe_to_sql_table(tbl,
                                   sqlite_max_variable_number=SQLITE_MAX_VARIABLE_NUMBER,
                                   quotechar='"',
                                   **kwargs):
+    import pdb
+    pdb.set_trace()
     bind = getbind(tbl, bind)
     dialect = bind.dialect.name
 

--- a/odo/backends/sql_csv.py
+++ b/odo/backends/sql_csv.py
@@ -5,7 +5,7 @@ import sys
 import subprocess
 import uuid
 import mmap
-from tempfile import NamedTemporaryFile, TemporaryFile
+from tempfile import NamedTemporaryFile
 
 from contextlib import closing
 from functools import partial

--- a/odo/backends/sql_csv.py
+++ b/odo/backends/sql_csv.py
@@ -382,6 +382,19 @@ def append_dataframe_to_sql_table(tbl,
 
     if dialect in DATAFRAME_TO_TABLE_IN_MEMORY_CSV:
         with StringIO() as buf:
+            NanIsNotNullFormatter(
+                df[[c.name for c in tbl.columns]],
+                buf,
+                index=False,
+                quotechar=quotechar,
+                doublequote=True,
+                # use quotechar for escape intentionally because it makes it
+                # easier to create a csv that pandas and postgres agree on
+                escapechar=quotechar,
+            ).save()
+            buf.flush()
+            buf.seek(0)
+
             return append_csv_to_sql_table(
                 tbl,
                 CSV(None,

--- a/odo/backends/tests/test_mssql.py
+++ b/odo/backends/tests/test_mssql.py
@@ -390,6 +390,10 @@ def test_to_dataframe_bit(sql_with_bit):
     assert df.bit2.dtype == 'bool'
     pd.util.testing.assert_frame_equal(df, expected)
 
+    ndarr = odo(sql, np.ndarray, bind=bind)
+    assert ndarr.bit1.dtype == 'bool'
+    assert ndarr.bit2.dtype == 'bool'
+
 
 def test_to_dataframe_money():
     from sqlalchemy import create_engine
@@ -416,6 +420,10 @@ def test_to_dataframe_money():
     assert df.money1.dtype == 'float'
     assert df.money2.dtype == 'float'
     pd.util.testing.assert_frame_equal(df, expected)
+
+    ndarr = odo(sql, np.ndarray, bind=bind)
+    assert ndarr.money1.dtype == 'float'
+    assert ndarr.money2.dtype == 'float'
     sql.drop()
 
 

--- a/odo/backends/tests/test_mssql.py
+++ b/odo/backends/tests/test_mssql.py
@@ -1,0 +1,416 @@
+from __future__ import absolute_import, division, print_function
+
+import pytest
+
+sa = pytest.importorskip('sqlalchemy')
+pyodbc = pytest.importorskip('pyodbc')
+
+import datetime
+import os
+import itertools
+import shutil
+
+from datashape import dshape
+import numpy as np
+import pandas as pd
+
+from odo.backends.csv import CSV
+from odo.backends.sql import select_to_base
+from odo import odo, into, resource, drop, discover, convert
+from odo.utils import assert_allclose, tmpfile
+
+try:
+    from urllib import quote_plus
+except ImportError:
+    from urllib.parse import quote_plus
+
+
+names = ('tbl%d' % i for i in itertools.count())
+new_schema = object()
+data = [(1, 2), (10, 20), (100, 200)]
+null_data = [(1, None), (10, 20), (100, 200)]
+
+
+skip_no_rw_loc = \
+    pytest.mark.skipif(1 == 0,
+                       reason=("Skipping tests with remote PG server (%s)"))
+
+
+@pytest.fixture(scope='module')
+def tmpdir():
+    return os.environ.get('MSSQL_TMP_DIR', None)
+
+
+@pytest.yield_fixture
+def csv(tmpdir):
+    s = '\n'.join(','.join(map(str, row)) for row in data).encode('utf8')
+    with tmpfile('.csv', dir=tmpdir) as fn:
+        with open(fn, 'wb') as f:
+            f.write(s)
+        yield CSV(fn)
+
+
+@pytest.yield_fixture
+def encoding_csv(tmpdir):
+    path = os.path.join(os.path.dirname(__file__), 'encoding.csv')
+    with tmpfile('.csv', dir=tmpdir) as fn:
+        with open(fn, 'wb') as f, open(path, 'r') as g:
+            f.write(g.read().encode('latin1'))
+        yield CSV(fn, columns=list('ab'))
+
+
+@pytest.yield_fixture
+def complex_csv(tmpdir):
+    path = os.path.join(os.path.dirname(__file__), 'dummydata.csv')
+    with tmpfile('.csv', dir=tmpdir) as fn:
+        shutil.copy(path, fn)
+        os.chmod(fn, 0o777)
+        yield CSV(fn, has_header=True)
+
+
+@pytest.fixture
+def url():
+    quoted = quote_plus('DRIVER={SQL Server};Server=localhost\sqlexpress;Database=test;Trusted_Connection=Yes;')
+    return 'mssql+pyodbc:///?odbc_connect={}::{}'.format(quoted, next(names))
+
+
+def sql_fixture(dshape, schema=None):
+    @pytest.yield_fixture(params=(True, False))
+    def fixture(request, url):
+        try:
+            t = resource(
+                url,
+                dshape=dshape,
+                schema=next(names) if schema is new_schema else schema,
+            )
+        except sa.exc.OperationalError as e:
+            pytest.skip(str(e))
+        else:
+            try:
+                bind = t.bind
+                if not request.param:
+                    t.metadata.bind = None
+                yield t, bind
+            finally:
+                t.metadata.bind = bind
+                drop(t)
+                if t.schema:
+                    bind.execute(sa.sql.ddl.DropSchema(t.schema))
+
+    return fixture
+
+
+sql = sql_fixture('var * {a: int32, b: ?int32}')
+sql_with_schema = sql_fixture('var * {a: int32, b: ?int32}', new_schema)
+sql_with_ugly_schema = sql_fixture('var * {a: int32, b: ?int32}', 'foo.b.ar')
+complex_sql = sql_fixture("""
+    var * {
+        Name: string, RegistrationDate: date, ZipCode: int32, Consts: float64
+    }
+""")
+sql_with_floats = sql_fixture('var * {a: float64, b: ?float64}')
+sql_with_dts = sql_fixture('var * {a: datetime, b: ?datetime}')
+sql_with_datelikes = sql_fixture("""
+    var * {
+        date: date,
+        option_date: ?date,
+        datetime: datetime,
+        option_datetime: ?datetime,
+    }
+""")
+sql_with_strings = sql_fixture("""
+    var * {non_optional: string, optional: ?string}
+""")
+
+
+@pytest.yield_fixture
+def quoted_sql(pg_ip, csv):
+    url = 'postgresql://postgres@{}/test::foo bar'.format(pg_ip)
+    try:
+        t = resource(url, dshape=discover(csv))
+    except sa.exc.OperationalError as e:
+        pytest.skip(str(e))
+    else:
+        try:
+            yield t
+        finally:
+            drop(t)
+
+
+@skip_no_rw_loc
+def test_simple_into(csv, sql):
+    sql, bind = sql
+    into(sql, csv, dshape=discover(sql), bind=bind)
+    assert into(list, sql, bind=bind) == data
+
+
+@skip_no_rw_loc
+def test_append(csv, sql):
+    sql, bind = sql
+    into(sql, csv, bind=bind)
+    assert into(list, sql, bind=bind) == data
+
+    into(sql, csv, bind=bind)
+    assert into(list, sql, bind=bind) == data + data
+
+
+def test_tryexcept_into(csv, sql):
+    sql, bind = sql
+    with pytest.raises(sa.exc.ProgrammingError):
+        # uses multi-byte character
+        into(sql, csv, lineterminator="alpha", bind=bind)
+
+
+@skip_no_rw_loc
+def test_no_header_no_columns(csv, sql):
+    sql, bind = sql
+    into(sql, csv, bind=bind, dshape=discover(sql))
+    assert into(list, sql, bind=bind) == data
+
+
+@skip_no_rw_loc
+def test_complex_into(complex_csv, complex_sql):
+    complex_sql, bind = complex_sql
+    # data from: http://dummydata.me/generate
+    into(complex_sql, complex_csv, dshape=discover(complex_sql), bind=bind)
+    assert_allclose(
+        into(list, complex_sql, bind=bind), into(list, complex_csv)
+    )
+
+
+@skip_no_rw_loc
+def test_sql_to_csv(sql, csv, tmpdir):
+    sql, bind = sql
+    sql = odo(csv, sql, bind=bind)
+    with tmpfile('.csv', dir=tmpdir) as fn:
+        csv = odo(sql, fn, bind=bind)
+        assert odo(csv, list) == data
+        assert discover(csv).measure.names == discover(sql).measure.names
+
+
+@skip_no_rw_loc
+def test_sql_select_to_csv(sql, csv, tmpdir):
+    sql, bind = sql
+    sql = odo(csv, sql, bind=bind)
+    query = sa.select([sql.c.a])
+    with tmpfile('.csv', dir=tmpdir) as fn:
+        csv = odo(query, fn, bind=bind)
+        assert odo(csv, list) == [(x,) for x, _ in data]
+
+
+@pytest.mark.xfail(reason="MSSQL BULK INSERT doesn't do escapechar")
+def test_invalid_escapechar(sql, csv):
+    sql, bind = sql
+    with pytest.raises(ValueError):
+        odo(csv, sql, escapechar='12', bind=bind)
+
+    with pytest.raises(ValueError):
+        odo(csv, sql, escapechar='', bind=bind)
+
+
+@pytest.mark.xfail(reason="MSSQL has no TSQL bulk export, so the ?int gets coerced to float")
+@skip_no_rw_loc
+def test_csv_output_is_not_quoted_by_default(sql, csv, tmpdir):
+    sql, bind = sql
+    sql = odo(csv, sql, bind=bind)
+    expected = "a,b\n1,2\n10,20\n100,200\n"
+    with tmpfile('.csv', dir=tmpdir) as fn:
+        csv = odo(sql, fn, bind=bind, dshape=discover(sql))
+        with open(fn, 'rt') as f:
+            result = f.read()
+        assert result == expected
+
+
+@pytest.mark.xfail(reason="MSSQL has no TSQL bulk export, so the ?int gets coerced to float")
+@skip_no_rw_loc
+def test_na_value(sql, csv, tmpdir):
+    sql, bind = sql
+    sql = odo(null_data, sql, bind=bind)
+    with tmpfile('.csv', dir=tmpdir) as fn:
+        csv = odo(sql, fn, na_value='NA', bind=bind)
+        with open(csv.path, 'rt') as f:
+            raw = f.read()
+    assert raw == 'a,b\n1,NA\n10,20\n100,200\n'
+
+
+@pytest.mark.xfail(reason="MSSQL uses code pages... not sure how to write this...")
+def test_different_encoding(url, encoding_csv):
+    try:
+        sql = odo(encoding_csv, url, encoding='latin1')
+    except sa.exc.OperationalError as e:
+        pytest.skip(str(e))
+    else:
+        try:
+            result = odo(sql, list)
+            expected = [(u'1958.001.500131-1A', 1, None, u'', 899),
+                        (u'1958.001.500156-6', 1, None, u'', 899),
+                        (u'1958.001.500162-1', 1, None, u'', 899),
+                        (u'1958.001.500204-2', 1, None, u'', 899),
+                        (u'1958.001.500204-2A', 1, None, u'', 899),
+                        (u'1958.001.500204-2B', 1, None, u'', 899),
+                        (u'1958.001.500223-6', 1, None, u'', 9610),
+                        (u'1958.001.500233-9', 1, None, u'', 4703),
+                        (u'1909.017.000018-3', 1, 30.0, u'sumaria', 899)]
+            assert result == expected
+        finally:
+            drop(sql)
+
+
+@skip_no_rw_loc
+def test_schema(csv, sql_with_schema):
+    sql_with_schema, bind = sql_with_schema
+    assert odo(odo(csv, sql_with_schema, bind=bind), list, bind=bind) == data
+
+
+@pytest.mark.xfail(reason="MSSQL thinks foo is a database")
+@skip_no_rw_loc
+def test_ugly_schema(csv, sql_with_ugly_schema):
+    sql_with_ugly_schema, bind = sql_with_ugly_schema
+    assert (
+        odo(odo(csv, sql_with_ugly_schema, bind=bind), list, bind=bind) ==
+        data
+    )
+
+
+def test_schema_discover(sql_with_schema):
+    sql_with_schema, bind = sql_with_schema
+    sql_with_schema.metadata.bind = bind
+    meta = discover(sql_with_schema.metadata)
+    assert meta == dshape('{%s: var * {a: int32, b: ?int32}}' %
+                          sql_with_schema.name)
+
+
+@pytest.mark.xfail(reason="bindparams is not working well... let me think about this")
+@skip_no_rw_loc
+def test_quoted_name(quoted_sql, csv):
+    s = odo(csv, quoted_sql)
+    t = odo(csv, list)
+    assert sorted(odo(s, list)) == sorted(t)
+
+
+def test_path_of_reduction(sql):
+    sql, bind = sql
+    result = list(convert.path(sa.select([sa.func.sum(sql.c.a)]), float))
+    expected = [(sa.sql.Select, float, select_to_base, 200)]
+    assert result == expected
+
+
+def test_drop_reflects_database_state(url):
+    data = list(zip(range(5), range(1, 6)))
+
+    t = odo(data, url, dshape='var * {A: int64, B: int64}')
+    assert t.exists()
+    assert resource(url).exists()
+
+    drop(url)
+    with pytest.raises(ValueError):
+        resource(url)  # Table doesn't exist and no dshape
+
+
+def test_nan_stays_nan(sql_with_floats):
+    sql_with_floats, bind = sql_with_floats
+
+    df = pd.DataFrame({'a': [np.nan, 1, 2], 'b': [3, np.nan, 4]})
+    odo(df, sql_with_floats, bind=bind)
+    rehydrated = odo(sql_with_floats, pd.DataFrame, bind=bind)
+    pd.util.testing.assert_frame_equal(rehydrated.sort_index(axis=1), df)
+
+    nulls_query = sa.select(sql_with_floats.c).where(
+        sql_with_floats.c.a.is_(None) | sql_with_floats.c.b.is_(None)
+    )
+    if bind is None:
+        nulls = nulls_query.execute()
+    else:
+        nulls = bind.execute(nulls_query)
+    assert not nulls.fetchall()
+
+
+def test_nat_to_null(sql_with_dts):
+    sql_with_dts, bind = sql_with_dts
+
+    df = pd.DataFrame({'a': pd.to_datetime(['2014-01-01', '2014-01-02']),
+                       'b': pd.to_datetime(['2014-01-01', 'nat'])})
+    odo(df, sql_with_dts, bind=bind)
+    rehydrated = odo(sql_with_dts, pd.DataFrame, bind=bind)
+    pd.util.testing.assert_frame_equal(rehydrated.sort_index(axis=1), df)
+
+    nulls_query = sa.select(sql_with_dts.c).where(
+        sql_with_dts.c.a.is_(None) | sql_with_dts.c.b.is_(None)
+    )
+    if bind is None:
+        nulls = nulls_query.execute()
+    else:
+        nulls = bind.execute(nulls_query)
+    assert nulls.fetchall() == [(pd.Timestamp('2014-01-02'), None)]
+
+
+def test_to_dataframe(sql):
+    sql, bind = sql
+    insert_query = sql.insert().values([{'a': 1, 'b': 2}, {'a': 3, 'b': 4}])
+    if bind is None:
+        insert_query.execute()
+    else:
+        bind.execute(insert_query)
+
+    df = odo(sql, pd.DataFrame, bind=bind)
+    expected = pd.DataFrame(np.array([(1, 2), (3, 4)],
+                                     dtype=[('a', 'int32'), ('b', 'float64')]))
+    pd.util.testing.assert_frame_equal(df, expected)
+
+
+def test_to_dataframe_datelike(sql_with_datelikes):
+    sql_with_datelikes, bind = sql_with_datelikes
+    date_0 = datetime.date(2014, 1, 1)
+    date_1 = datetime.date(2014, 1, 2)
+    datetime_0 = datetime.datetime(2014, 1, 1)
+    datetime_1 = datetime.datetime(2014, 1, 2)
+    insert_query = sql_with_datelikes.insert().values([
+        {'date': date_0,
+         'option_date': date_0,
+         'datetime': datetime_0,
+         'option_datetime': datetime_0},
+        {'date': date_1,
+         'option_date': date_1,
+         'datetime': datetime_1,
+         'option_datetime': datetime_1},
+    ])
+    if bind is None:
+        insert_query.execute()
+    else:
+        bind.execute(insert_query)
+
+    df = odo(sql_with_datelikes, pd.DataFrame, bind=bind)
+    expected = pd.DataFrame([[datetime_0] * 4, [datetime_1] * 4],
+                            columns=['date',
+                                     'option_date',
+                                     'datetime',
+                                     'option_datetime'])
+    pd.util.testing.assert_frame_equal(df, expected)
+
+
+def test_to_dataframe_strings(sql_with_strings):
+    sql_with_strings, bind = sql_with_strings
+
+    insert_query = sql_with_strings.insert().values([
+        {'non_optional': 'ayy', 'optional': 'hello "world"'},
+        {'non_optional': 'lmao', 'optional': None},
+    ])
+    if bind is None:
+        insert_query.execute()
+    else:
+        bind.execute(insert_query)
+
+    df = odo(sql_with_strings, pd.DataFrame, bind=bind)
+    expected = pd.DataFrame([['ayy', 'hello "world"'], ['lmao', None]],
+                            columns=['non_optional', 'optional'])
+    pd.util.testing.assert_frame_equal(df, expected)
+
+
+def test_from_dataframe_strings(sql_with_strings):
+    sql_with_strings, bind = sql_with_strings
+
+    input_ = pd.DataFrame([['ayy', 'hello "world"'], ['lmao', None]],
+                          columns=['non_optional', 'optional'])
+    odo(input_, sql_with_strings, bind=bind)
+    output = odo(sql_with_strings, pd.DataFrame, bind=bind)
+    pd.util.testing.assert_frame_equal(output, input_)

--- a/odo/numpy_dtype.py
+++ b/odo/numpy_dtype.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import, division, print_function
 
 import numpy as np
 from datashape import dshape, DataShape, Option, DateTime, string, TimeDelta
-from datashape import Date, to_numpy_dtype, Tuple, String, Decimal
+from datashape import Date, to_numpy_dtype, Tuple, String, Decimal, bool_
 from datashape.predicates import isscalar, isnumeric, isrecord
 
 
@@ -42,6 +42,11 @@ def unit_to_dtype(ds):
                 str_np_dtype = 'float16'
             return unit_to_dtype(str_np_dtype)
         return unit_to_dtype(str(ds).replace('int', 'float').replace('?', ''))
+    if isinstance(ds, Option):
+        if ds.ty == bool_:
+            # NumPy doesn't support ?bool, so coerce to bool
+            # This will coerce NULL booleans/bits to False...
+            return unit_to_dtype('bool')
     if isinstance(ds, Option) and isinstance(
         ds.ty, (Date, DateTime, String, TimeDelta)
     ):


### PR DESCRIPTION
Hello,

So I've made some progress on getting MSSQL work with this. This is nowhere near ready. Got a couple of preference-type questions:

* There are (at least) [5 different ways](http://docs.sqlalchemy.org/en/latest/dialects/mssql.html#module-sqlalchemy.dialects.mssql.pyodbc) to connect to MSSQL from sqlalchmey. I've really only played with pyodbc--I've had generally good luck with ODBC in general on windows and it works in python. So I plan to focus on the `mssql+pyodbc` connection.  UPDATE: This now uses `mssql+pymssql` because getting username, password, and trusted connection is more obvious to me.
* To bulk import/export data there are really 3 choices ([here's a more detailed breakdown](https://msdn.microsoft.com/en-us/library/ms175937.aspx))
  * The command line `bcp` utility. It is installed with SQL Server. Downsides to the `bcp` utility is that it is entirely run from the command prompt and you have to provide a server name. If you are using ODBC (or an ODBC DSN), I'm unsure how to get the servername from the ODBC connection. 
  * The `BULK INSERT` command which can be run from the TSQL interface. The downsides are that you must provide a file path which is a server-side read. So if the *.csv file is on a client computer, getting the SQL server to see the file and upload it can be a challenge. Also, the `BULK INSERT` is an "insert-only" command. There's no `BULK EXPORT` to csv functionality (which odo uses is the `sql.py` file, so we have to use a fallback through the iterators. 
  * The `OPENROWSET` statement in an `INSERT`. Basically, the same benefits (and drawbacks) of `BULK INSERT`. 
* I'm using bcp.exe and deriving the parameters from `pymssql`. If there was a way to get the connection parameters (servername, username, password, etc.) from `pyodbc`, that would be great. Open for ideas. 

ToDo:

* [x] bit support: not that i had to edit the `unit_to_dtype` code so that `?bool` -> `'bool`. This appears to coerce `NULL` bools to `False`.
* [x] money support
* [x] bcp export doesn't do headers. I think creating 2 files and `copy /b` them together is the way to go. 
* [x] bcp result message parsing (currently ignoring everything) - Error parsing is a little rough. SQL server likes to give warnings that blanks become nulls...
* [x] not sure if pipe (|) delimiters work (I use them a lot... I tend to have commas in data, e.g., street address of 123 Main St., Apt 3)
* [ ] need a reviewer (I'll confess I'm not a professional programmer)

MaybeDo:
* [ ] datetimeoffset support (? this is kind of hard, I think)
* [ ] pyodbc support through connection string
* [ ] add pymssql or pyodbc to requirements/setup.py
* [ ] fallback to bulk insert, then standard `INSERT` if bcp insert won't work (maybe if pyodbc used and it doesn't make sense)
* [ ] fallback to sqlalchemy export if bcp won't work. 
* [ ] For BCP, I'm a little unclear which code page or encoding thing I should use. Seems like `-c` seems like the best. I'm confused about the others.

Thanks!
