### PR TITLE
Fix syntax for sqlalchemy-redshift CopyCommand

### DIFF
--- a/odo/backends/sql_csv.py
+++ b/odo/backends/sql_csv.py
@@ -197,7 +197,7 @@ else:
 
         compression = getattr(element, 'compression', '').upper() or None
         cmd = CopyCommand(
-            table=element.element,
+            to=element.element,
             data_location=element.csv.path,
             access_key_id=aws_access_key_id,
             secret_access_key=aws_secret_access_key,


### PR DESCRIPTION
I'm not sure why this line uses the keyword argument "table" - I can't find any docs, past or present, of CopyCommand using that syntax. This fixes an error I had when copying csv to redshift.