### PR TITLE
WIP/ENH: bcolz coerce to ascii

### DIFF
--- a/odo/convert.py
+++ b/odo/convert.py
@@ -195,7 +195,14 @@ def list_to_numpy(seq, dshape=None, **kwargs):
     if (seq and isinstance(seq[0], Iterable) and not ishashable(seq[0]) and
             not isscalar(dshape)):
         seq = list(map(tuple, seq))
-    return np.array(seq, dtype=dshape_to_numpy(dshape))
+    try:
+        return np.array(seq, dtype=dshape_to_numpy(dshape))
+    except UnicodeEncodeError:
+        ds = dshape_to_numpy(dshape)
+        for i, rec in enumerate(seq):
+            seq[i] = tuple(str(r).encode('utf-8') if (ds[k].kind == 'S') else r
+                           for k, r in enumerate(rec))
+        return np.array(seq, dtype=ds)
 
 
 @convert.register(Iterator, list, cost=0.001)

--- a/odo/convert.py
+++ b/odo/convert.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import, division, print_function
 
 import numpy as np
+import sys
 import pandas as pd
 from datashape.predicates import isscalar
 from toolz import concat, partition_all, compose
@@ -200,8 +201,14 @@ def list_to_numpy(seq, dshape=None, **kwargs):
     except UnicodeEncodeError:
         ds = dshape_to_numpy(dshape)
         for i, rec in enumerate(seq):
-            seq[i] = tuple(str(r).encode('utf-8') if (ds[k].kind == 'S') else r
-                           for k, r in enumerate(rec))
+            if sys.version_info.major == 3:
+                seq[i] = tuple(str(r).encode('utf-8')
+                               if (ds[k].kind == 'S') else r
+                               for k, r in enumerate(rec))
+            else:
+                seq[i] = tuple(unicode(r).encode('utf-8')
+                               if (ds[k].kind == 'S') else r
+                               for k, r in enumerate(rec))
         return np.array(seq, dtype=ds)
 
 

--- a/odo/tests/test_convert.py
+++ b/odo/tests/test_convert.py
@@ -303,7 +303,11 @@ def test_iterator_to_df():
 
 
 def test_unicode_ndarray_to_ascii():
-    L = [u'\x96']
-    L2 = convert(np.ndarray, L, dshape=dshape("1 * string[5, 'A']"))
-    expected = [L[0].encode('utf-8')]
-    assert expected == L2
+    from numpy.testing import assert_array_equal
+    L = [(u'\x96', 1), (u'a', 2)]
+    L2 = convert(np.ndarray, L, dshape=dshape("""var{a: string[5, 'A'],
+                                                     b: int32}"""))
+    expected = np.array([(u'\x96'.encode('utf-8'), 1),
+                         (u'a'.encode('utf-8'), 2)],
+                        dtype=[('a', 'S5'), ('b', '<i4')])
+    assert_array_equal(expected, L2)

--- a/odo/tests/test_convert.py
+++ b/odo/tests/test_convert.py
@@ -300,3 +300,10 @@ def test_iterator_to_df():
     it = iter([1, 2, 3])
     df = convert(pd.DataFrame, it)
     assert df[0].tolist() == [1, 2, 3]
+
+
+def test_unicode_ndarray_to_ascii():
+    L = [u'\x96']
+    L2 = convert(np.ndarray, L, dshape=dshape("1 * string[5, 'A']"))
+    expected = [L[0].encode('utf-8')]
+    assert expected == L2


### PR DESCRIPTION
Hello,

So I have another idea... this one I can imagine might not fly. 

Long story short, is I have data in a MSSQL server that I'm trying to get into bcolz. The MSSQL PR #525 will let me pull from the server pretty nicely. 

The next problem I've run into is that the data in MSSQL is essentially unicode, but bcolz (and numexpr) don't like unicode--they prefer strings. So much so that by default when you run the `bcolz.fromdataframe` command, it attempts to coerce  all strings to  ascii/bytes as well. 

I propose to  make that conversion a little easier... Here's an idea. 

Let me know if this is useful. 

An example of why this might be useful... 

I have a field of vehicle types in a SQL table... think `F-150`, `COROLLA`, `CAMRY`,  etc. When I use `odo` to move this to bcolz,, 100,000 records becomes 1235 separate *. blp files. Using this, I can cut that down to 306 files.