### PR TITLE
pd.NaTType is removed in pandas 0.20

### DIFF
--- a/odo/backends/pandas.py
+++ b/odo/backends/pandas.py
@@ -99,7 +99,7 @@ def nan_to_nat(fl, **kwargs):
     raise NotImplementedError()
 
 
-@convert.register((pd.Timestamp, pd.Timedelta), (pd.tslib.NaTType, type(None)))
+@convert.register((pd.Timestamp, pd.Timedelta), (type(pd.NaT), type(None)))
 def convert_null_or_nat_to_nat(n, **kwargs):
     return pd.NaT
 


### PR DESCRIPTION
In pandas 0.20 there is no longer a "pd.NaTType".  Replaced with "type(pd.NaT)"