### PR TITLE
Fix usage of deprecated pandas api

### DIFF
--- a/odo/backends/pandas.py
+++ b/odo/backends/pandas.py
@@ -99,7 +99,7 @@ def nan_to_nat(fl, **kwargs):
     raise NotImplementedError()
 
 
-@convert.register((pd.Timestamp, pd.Timedelta), (pd.tslib.NaTType, type(None)))
+@convert.register((pd.Timestamp, pd.Timedelta), (type(pd.NaT), type(None)))
 def convert_null_or_nat_to_nat(n, **kwargs):
     return pd.NaT
 


### PR DESCRIPTION
The `tslib` namespace is [`deprecated`](https://github.com/pandas-dev/pandas/pull/16146).

Calling `type(pd.NaT)` is equivalent and works even on pandas `0.15.0`.