### PR TITLE
Microsoft SQL Server bcp import/export

### DIFF
--- a/odo/backends/sql.py
+++ b/odo/backends/sql.py
@@ -915,6 +915,28 @@ def compile_copy_to_csv_sqlite(element, compiler, **kwargs):
     # This will be a no-op since we're doing the write during the compile
     return ''
 
+@compiles(CopyToCSV, 'mssql')
+def compile_copy_to_csv_mssql(element, compiler, **kwargs):
+    selectable = element.element
+
+    connection_elements = selectable.bind.url.query['odbc_connect'].replace('=',';').split(';')
+    connection_elements = dict(zip(connection_elements[0::2], connection_elements[1::2]))
+
+    cmd_template = """bcp {database}.{schema}.{table} OUT {path} -S {server} -T -c -q"""
+    cmd_statement = cmd_template.format(database=connection_elements['DATABASE'],
+                                        schema=selectable.schema,
+                                        table=selectable.name,
+                                        path=element.path.replace('\\\\','\\'),
+                                        server=connection_elements['SERVER'])
+
+    try:
+        _call = subprocess.Popen(cmd_statement, stderr=subprocess.PIPE)
+        out, err = _call.communicate()
+    except OSError as e:
+        return e
+    except subprocess.CalledProcessError:
+        return "Error: {0} Return Code: {1}".format(err, _call.returncode)
+    return _call.returncode
 
 try:
     from sqlalchemy_redshift.dialect import UnloadFromSelect

--- a/odo/backends/sql.py
+++ b/odo/backends/sql.py
@@ -922,12 +922,14 @@ def compile_copy_to_csv_mssql(element, compiler, **kwargs):
     connection_elements = selectable.bind.url.query['odbc_connect'].replace('=',';').split(';')
     connection_elements = dict(zip(connection_elements[0::2], connection_elements[1::2]))
 
-    cmd_template = """bcp {database}.{schema}.{table} OUT {path} -S {server} -T -c -q"""
+    cmd_template = """bcp {database}.{schema}.{table} OUT {path} -S {server} -T -c -r{lineterm} -t"{delim}" -q"""
     cmd_statement = cmd_template.format(database=connection_elements['DATABASE'],
                                         schema=selectable.schema,
                                         table=selectable.name,
-                                        path=element.path.replace('\\\\','\\'),
-                                        server=connection_elements['SERVER'])
+                                        path=element.path,
+                                        server=connection_elements['SERVER'],
+                                        lineterm=element.lineterminator,
+                                        delim=element.delimiter)
 
     try:
         _call = subprocess.Popen(cmd_statement, stderr=subprocess.PIPE)

--- a/odo/backends/sql_csv.py
+++ b/odo/backends/sql_csv.py
@@ -184,12 +184,14 @@ def compile_from_csv_mssql(element, compiler, **kwargs):
     connection_elements = selectable.bind.url.query['odbc_connect'].replace('=',';').split(';')
     connection_elements = dict(zip(connection_elements[0::2], connection_elements[1::2]))
 
-    cmd_template = """bcp {database}.{schema}.{table} IN {path} -S {server} -T -c -q"""
+    cmd_template = """bcp {database}.{schema}.{table} IN {path} -S {server} -T -c -r{lineterm} -t"{delim}" -q"""
     cmd_statement = cmd_template.format(database=connection_elements['DATABASE'],
                                         schema=selectable.schema,
                                         table=selectable.name,
                                         path=element.csv.path,
-                                        server=connection_elements['SERVER'])
+                                        server=connection_elements['SERVER'],
+                                        lineterm = element.lineterminator,
+                                        delim= element.delimiter)
 
     try:
         _call = subprocess.Popen(cmd_statement, stderr=subprocess.PIPE)


### PR DESCRIPTION
Added bcp functionality for odo within the framework of the other copy to/from flat file loaders. Tried to cover kwarg support for items like delimiter and newline settings. Using popen so that any error can be captured and populated. OSError will provide an error if bcp is not installed. One concern I have is building the Server.Database.Schema information. Currently I did this by slicing up the connection string that is given to sqlalchemy into a dict because I didn't see the server/db information in the element. Any feedback on a better way to accomplish retrieving that data that could be more stable would be appreciated.