### PR TITLE
BUG: Fix discover for sa.TIMESTAMP.

### DIFF
--- a/odo/backends/sql.py
+++ b/odo/backends/sql.py
@@ -83,6 +83,19 @@ types = {
 
 revtypes = dict(map(reversed, types.items()))
 
+# Subclass mssql.TIMESTAMP subclass for use when differentiating between
+# mssql.TIMESTAMP and sa.TIMESTAMP.
+# At the time of this writing, (mssql.TIMESTAMP == sa.TIMESTAMP) is True,
+# which causes a collision when defining the revtypes mappings.
+# 
+# See:
+# https://bitbucket.org/zzzeek/sqlalchemy/issues/4092/type-problem-with-mssqltimestamp
+class MSSQLTimestamp(mssql.TIMESTAMP):
+    pass
+
+# Assign the custom subclass as the type to use instead of `mssql.TIMESTAMP`.
+mssql.base.ischema_names['TIMESTAMP'] = MSSQLTimestamp
+
 revtypes.update({
     sa.DATETIME: datetime_,
     sa.TIMESTAMP: datetime_,
@@ -103,7 +116,7 @@ revtypes.update({
     mssql.UNIQUEIDENTIFIER: string,
     # The SQL Server TIMESTAMP value doesn't correspond to the ISO Standard
     # It is instead just a binary(8) value with no relation to dates or times
-    mssql.TIMESTAMP: bytes_,
+    MSSQLTimestamp: bytes_,
 })
 
 # interval types are special cased in discover_typeengine so remove them from

--- a/odo/backends/tests/test_sql.py
+++ b/odo/backends/tests/test_sql.py
@@ -6,6 +6,7 @@ pytest.importorskip('sqlalchemy')
 import os
 from decimal import Decimal
 from functools import partial
+from textwrap import dedent
 
 import datashape
 from datashape import (
@@ -304,7 +305,16 @@ def test_discover_oracle_intervals(freq):
         (sa.types.NullType, string),
         (sa.REAL, float32),
         (sa.Float, float64),
-        # sa.Float(precision=24), float32 (reason="Currently returns float64")
+        pytest.param(
+            sa.Float(precision=24), float32,
+            marks=pytest.mark.xfail(
+                reason=dedent("""
+                Currently returns float64.
+                Unique instances of sa.Float(precision=24) do not equate to each other, which prevents
+                discover_typeengine from correctly keying into sql.revparses.
+                """).strip()
+            )
+        ),
         (sa.Float(precision=53), float64),
     ),
 )


### PR DESCRIPTION
`discover` was returning a bytes dtype for the `sa.TIMESTAMP` instead of
`datetime_`.

That bug was because the SQLAlchemy dialect for MSSQL currently directly imports
`sa.TIMESTAMP`, causing a collision in `odo.backends.sql.revtypes`.

Fix by 1) creating a subclass of `mssql.TIMESTAMP` to use as the key in
`revtypes` so that it does not overwrite `sa.TIMESTAMP` 2) assign that subclass
to the mssql dialect's `'TIMESTAMP'` (using `ischema_names`), so that the
subclass will be returned by the type engine instead of `mssql.TIMESTAMP`.

The added test for the (`sa.TIMESTAMP`, `datetime_`) without the fix applied
would result in this error:
```
a = Bytes(), b = DateTime(tz=None), path = ('.measure', "['ts']", '.ty')
kwargs = {'check_dim': True, 'check_record_order': True}

    @assert_dshape_equal.register(object, object)
    def _base_case(a, b, path=None, **kwargs):
>       assert a == b, '%s != %s\n%s' % (a, b, _fmt_path(path))
E       AssertionError: bytes != datetime
E       path: _.measure['value'].ty
```

This patch includes checks for the other types besides `sa.TIMESTAMP` for better
protection against the general case of failures when using `revtypes` to map
SQLAlchemy types to dtypes.

Those extra cases exposed an issue with `sa.Float(precision=24)`.
That case is commented out to keep the fix of this patch on the `sa.TIMESTAMP` mapping.
(I would have used `pytest.param` to mark it xfail, but pytest for this project needs to be
upgraded first.)

See:
https://github.com/blaze/odo/issues/567
https://github.com/blaze/odo/pull/568
https://bitbucket.org/zzzeek/sqlalchemy/issues/4092/type-problem-with-mssqltimestamp
https://github.com/blaze/blaze/pull/1656