### PR TITLE
TST: Upgrade pytest to latest.

### DIFF
--- a/etc/requirements_ci.txt
+++ b/etc/requirements_ci.txt
@@ -28,12 +28,12 @@ paramiko==2.0.2
 partd==0.3.6
 psutil==4.4.2
 psycopg2==2.6.2
-py==1.4.31
+py==1.4.34
 pyasn1==0.1.9
 pycparser==2.17
 pymongo==2.9.4
 PyMySQL==0.7.9
-pytest==3.0.3
+pytest==3.2.3
 python-dateutil==2.5.3
 pytz==2016.7
 pywebhdfs==0.4.1


### PR DESCRIPTION
Rerunning the tests with the upgraded pytest produces the same number of passing
and xfailed tests.

With pytest 3.2.3, 5 warnings are now shown.
pytest 3.1.0 changed behavior so that warnings are captured and displayed.
https://docs.pytest.org/en/latest/changelog.html#id81

The impetus for upgrading is that in another patch, using `pytest.param` to mark a
specific parameter as an xfail would have been useful; `pytest.param` was added
in 3.1.0