### PR TITLE
BUG: Fix reflection Postgres double precision columns.

### DIFF
--- a/odo/backends/tests/test_postgres.py
+++ b/odo/backends/tests/test_postgres.py
@@ -11,6 +11,7 @@ import itertools
 import shutil
 
 from datashape import dshape
+from datashape.util.testing import assert_dshape_equal
 import numpy as np
 import pandas as pd
 
@@ -425,3 +426,15 @@ def test_from_dataframe_strings(sql_with_strings):
     odo(input_, sql_with_strings, bind=bind)
     output = odo(sql_with_strings, pd.DataFrame, bind=bind)
     pd.util.testing.assert_frame_equal(output, input_)
+
+
+def test_float_dtype(sql_with_floats):
+    sql_with_floats, bind = sql_with_floats
+
+    expected = dshape("var * {a: float64, b: ?float64}")
+
+    assert_dshape_equal(discover(sql_with_floats), expected)
+
+    # Also check that reflection from the database returns expected dshape.
+    assert_dshape_equal(discover(bind).subshape[sql_with_floats.name],
+                        expected)

--- a/odo/backends/tests/test_sql.py
+++ b/odo/backends/tests/test_sql.py
@@ -305,7 +305,9 @@ def test_discover_oracle_intervals(freq):
         (sa.types.NullType, string),
         (sa.REAL, float32),
         (sa.Float, float64),
+        (sa.Float(precision=8), float32),
         (sa.Float(precision=24), float32),
+        (sa.Float(precision=42), float64),
         (sa.Float(precision=53), float64),
     ),
 )
@@ -313,6 +315,21 @@ def test_types(typ, dtype):
     expected = var * R['value': Option(dtype)]
     t = sa.Table('t', sa.MetaData(), sa.Column('value', typ))
     assert_dshape_equal(discover(t), expected)
+
+
+@pytest.mark.parametrize(
+    'typ', (
+        sa.Float(precision=-1),
+        sa.Float(precision=0),
+        sa.Float(precision=54)
+    )
+)
+def test_unsupported_precision(typ):
+    t = sa.Table('t', sa.MetaData(), sa.Column('value', typ))
+    with pytest.raises(ValueError) as err:
+        discover(t)
+    assert str(err.value) == "{} is not a supported precision".format(
+        typ.precision)
 
 
 def test_mssql_types():

--- a/odo/backends/tests/test_sql.py
+++ b/odo/backends/tests/test_sql.py
@@ -305,16 +305,7 @@ def test_discover_oracle_intervals(freq):
         (sa.types.NullType, string),
         (sa.REAL, float32),
         (sa.Float, float64),
-        pytest.param(
-            sa.Float(precision=24), float32,
-            marks=pytest.mark.xfail(
-                reason=dedent("""
-                Currently returns float64.
-                Unique instances of sa.Float(precision=24) do not equate to each other, which prevents
-                discover_typeengine from correctly keying into sql.revparses.
-                """).strip()
-            )
-        ),
+        (sa.Float(precision=24), float32),
         (sa.Float(precision=53), float64),
     ),
 )
@@ -322,7 +313,7 @@ def test_types(typ, dtype):
     expected = var * R['value': Option(dtype)]
     t = sa.Table('t', sa.MetaData(), sa.Column('value', typ))
     assert_dshape_equal(discover(t), expected)
-    
+
 
 def test_mssql_types():
     typ = sa.dialects.mssql.BIT()


### PR DESCRIPTION
A double precision column in a Postrges table, whose dshape specified a dtype of
`float64` for that column, would return a decimal dtype.

Fix by defining a group of types which are 'precision' types, and check for
membership in that before attempting to lookup the typeengine typ in
`blaze.backends.sql.revtypes`

Without the fix applied the newly added test fails with the following assertion
error, when comparing the `discover` of the `bind` with the expected values:
```
    @assert_dshape_equal.register(object, object)
    def _base_case(a, b, path=None, **kwargs):
>       assert a == b, '%s != %s\n%s' % (a, b, _fmt_path(path))
E       AssertionError: decimal[precision=53, scale=None] != float64
E       path: _.measure['a']
```

Also, added `sa.Float` as a precision type, which fixes
`sa.Float(precision=24)`; this allows removal of the `xfail` marking in
`odo/backends/test/test_sql::test_types`.