### PR TITLE
Fix detection of integral dtypes

### DIFF
--- a/odo/backends/pandas.py
+++ b/odo/backends/pandas.py
@@ -14,7 +14,11 @@ from ..convert import convert
 
 
 possibly_missing = frozenset({string, datetime_})
-categorical = type(pd.Categorical.dtype)
+try:
+    from pandas.api.types import CategoricalDtype as categorical
+except ImportError:
+    categorical = type(pd.Categorical.dtype)
+    assert categorical is not property
 
 
 def dshape_from_pandas(col):

--- a/odo/backends/tests/test_bokeh.py
+++ b/odo/backends/tests/test_bokeh.py
@@ -15,9 +15,8 @@ df = pd.DataFrame([[100, 'Alice'],
 
 def test_convert_dataframe_to_cds():
     cds = convert(ColumnDataSource, df)
-    assert cds.data == {'name': ['Alice', 'Bob', 'Charlie'],
-                        'balance': [100, 200, 300]}
-
+    assert list(cds.data['name']) == ['Alice', 'Bob', 'Charlie']
+    assert list(cds.data['balance']) == [100, 200, 300]
     df2 = convert(pd.DataFrame, cds)
     assert isinstance(df2, pd.DataFrame)
 


### PR DESCRIPTION
**TL;DR;**
`if ty in datashape.integral` doesn't detect `?decimal[precision=1, scale=0]` as integral but `ty.to_numpy_dtype()` returns `np.int32` which then blows up on nulls (None)

**Also Fixes:**
- #556
- #597