### PR TITLE
Make odo compatible with NetworkX >=2.0

### DIFF
--- a/etc/ci-install.sh
+++ b/etc/ci-install.sh
@@ -1,3 +1,5 @@
+set -x
+
 # Install dependencies
 # Use conda **ONLY** for numpy and pandas (if not pulling from master), this
 # speeds up the builds a lot. Use the normal pip install for the rest.

--- a/etc/ci-install.sh
+++ b/etc/ci-install.sh
@@ -3,7 +3,7 @@ set -x
 # Install dependencies
 # Use conda **ONLY** for numpy and pandas (if not pulling from master), this
 # speeds up the builds a lot. Use the normal pip install for the rest.
-conda create -n odo numpy=1.11.2 python=$python
+conda create -n odo numpy=1.11.2 python=${TRAVIS_PYTHON_VERSION}
 source activate odo
 
 # update setuptools and pip
@@ -24,5 +24,3 @@ pip install -r etc/requirements_ci.txt
 
 # datashape
 pip install git+git://github.com/blaze/datashape.git
-
-pip list

--- a/etc/ci-install.sh
+++ b/etc/ci-install.sh
@@ -22,3 +22,5 @@ pip install -r etc/requirements_ci.txt
 
 # datashape
 pip install git+git://github.com/blaze/datashape.git
+
+pip list

--- a/odo/compatibility.py
+++ b/odo/compatibility.py
@@ -39,3 +39,12 @@ try:
     from urllib2 import urlopen
 except ImportError:
     from urllib.request import urlopen
+
+import networkx
+if networkx.__version__.startswith('1.'):
+    def adjacency(g):
+        return g.edge
+else:
+    # NetworkX >=2.0
+    def adjacency(g):
+        return dict(g.adjacency())

--- a/odo/core.py
+++ b/odo/core.py
@@ -9,7 +9,7 @@ import networkx as nx
 import numpy as np
 from toolz import concatv
 
-from .compatibility import map
+from .compatibility import map, adjacency
 from .utils import expand_tuples, ignoring
 
 
@@ -169,7 +169,7 @@ def path(graph, source, target, excluded_edges=None, ooc_types=ooc_types):
                                     if issubclass(n, oocs)])
     with without_edges(graph, excluded_edges) as g:
         pth = nx.shortest_path(g, source=source, target=target, weight='cost')
-        edge = graph.edge
+        edge = adjacency(graph)
 
         def path_part(src, tgt):
             node = edge[src][tgt]
@@ -188,8 +188,9 @@ def path_cost(path):
 def without_edges(g, edges):
     edges = edges or []
     held = dict()
+    _g_edge = adjacency(g)
     for a, b in edges:
-        held[(a, b)] = g.edge[a][b]
+        held[(a, b)] = _g_edge[a][b]
         g.remove_edge(a, b)
 
     try:


### PR DESCRIPTION
NetworkX changed its API for accessing edges.  This PR makes odo compatible with NetworkX 1.0/2.0 by adding a compatibility function for each version of NetworkX.

Fixes #615 