### PR TITLE
Fix unsupported function call inspect.getargspec

### DIFF
--- a/odo/utils.py
+++ b/odo/utils.py
@@ -127,7 +127,7 @@ def keywords(func):
     """
     if isinstance(func, type):
         return keywords(func.__init__)
-    return inspect.getargspec(func).args
+    return inspect.getfullargspec(func).args
 
 
 def cls_name(cls):


### PR DESCRIPTION
Note: I am using Python 3.7.
Call to inspect.getargspec is throwing following error message:
ValueError: Function has keyword-only parameters or annotations, use getfullargspec() API which can support them.
As suggested in the error message, changing the call to inspect.getfullargspec.
Possibly function name getargspec is changed to getfullargspec in the inspect package.