### PR TITLE
Import Iterator/Iterable from collections.abc

### DIFF
--- a/odo/backends/aws.py
+++ b/odo/backends/aws.py
@@ -6,7 +6,7 @@ import zlib
 import re
 from fnmatch import fnmatch
 from contextlib import contextmanager
-from collections import Iterator
+from collections.abc import Iterator
 from operator import attrgetter
 from io import BytesIO
 

--- a/odo/backends/dask.py
+++ b/odo/backends/dask.py
@@ -1,5 +1,5 @@
 from __future__ import absolute_import, division, print_function
-from collections import Iterator
+from collections.abc import Iterator
 
 import numpy as np
 import pandas as pd

--- a/odo/backends/hdfs.py
+++ b/odo/backends/hdfs.py
@@ -14,7 +14,8 @@ import datashape
 import sqlalchemy as sa
 from datashape import discover
 from datashape import coretypes as ct
-from collections import namedtuple, Iterator
+from collections import namedtuple
+from collections.abc import Iterator
 from contextlib import contextmanager
 from .ssh import SSH
 from .sql import metadata_of_engine

--- a/odo/backends/json.py
+++ b/odo/backends/json.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import, division, print_function
 
 import json
 from toolz.curried import map, take, pipe, pluck, get, concat, filter
-from collections import Iterator, Iterable
+from collections.abc import Iterator, Iterable
 import os
 from contextlib import contextmanager
 

--- a/odo/backends/mongo.py
+++ b/odo/backends/mongo.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import, division, print_function
 
 import pymongo
 from pymongo.collection import Collection
-from collections import Iterator
+from collections.abc import Iterator
 from datashape import discover, DataShape, Record, var
 from datashape.predicates import isdimension
 from datashape.dispatch import dispatch

--- a/odo/backends/sas.py
+++ b/odo/backends/sas.py
@@ -5,7 +5,7 @@ from sas7bdat import SAS7BDAT
 
 import datashape
 from datashape import discover, dshape, var, Record, date_, datetime_
-from collections import Iterator
+from collections.abc import Iterator
 import pandas as pd
 from .pandas import coerce_datetimes
 from ..append import append

--- a/odo/backends/sparksql.py
+++ b/odo/backends/sparksql.py
@@ -7,7 +7,7 @@ import tempfile
 import shutil
 
 from functools import partial
-from collections import Iterator
+from collections.abc import Iterator
 from datetime import datetime, date
 
 import pandas as pd

--- a/odo/backends/sql.py
+++ b/odo/backends/sql.py
@@ -11,7 +11,7 @@ from functools import partial
 
 from operator import attrgetter
 from itertools import chain
-from collections import Iterator
+from collections.abc import Iterator
 from datetime import datetime, date, timedelta
 from distutils.spawn import find_executable
 

--- a/odo/backends/tests/test_csv.py
+++ b/odo/backends/tests/test_csv.py
@@ -10,7 +10,7 @@ import pandas.util.testing as tm
 import gzip
 import datashape
 from datashape import Option, string
-from collections import Iterator
+from collections.abc import Iterator
 
 from odo.backends.csv import (CSV, append, convert, resource,
                               csv_to_dataframe, CSV_to_chunks_of_dataframes,

--- a/odo/backends/tests/test_sas.py
+++ b/odo/backends/tests/test_sas.py
@@ -5,7 +5,7 @@ sas7bdat = pytest.importorskip('sas7bdat')
 pytest.importorskip('odo.backends.sas')
 import os
 import pandas as pd
-from collections import Iterator
+from collections.abc import Iterator
 from sas7bdat import SAS7BDAT
 
 from odo.backends.sas import discover, sas_to_iterator

--- a/odo/backends/text.py
+++ b/odo/backends/text.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import, division, print_function
 
 import gzip
 from datashape import discover, dshape
-from collections import Iterator
+from collections.abc import Iterator
 from toolz import partial, concat
 import uuid
 import os

--- a/odo/chunks.py
+++ b/odo/chunks.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import, division, print_function
 
-from collections import Iterator
+from collections.abc import Iterator
 
 from toolz import memoize, first, peek
 from datashape import discover, var

--- a/odo/convert.py
+++ b/odo/convert.py
@@ -4,7 +4,7 @@ import numpy as np
 import pandas as pd
 from datashape.predicates import isscalar
 from toolz import concat, partition_all, compose
-from collections import Iterator, Iterable
+from collections.abc import Iterator, Iterable
 import datashape
 from datashape import discover
 from .core import NetworkDispatcher, ooc_types

--- a/odo/core.py
+++ b/odo/core.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import, division, print_function
 
-from collections import namedtuple, Iterator
+from collections import namedtuple
+from collections.abc import Iterator
 from contextlib import contextmanager
 from warnings import warn
 

--- a/odo/tests/test_convert.py
+++ b/odo/tests/test_convert.py
@@ -7,7 +7,7 @@ from odo.convert import (convert, list_to_numpy, iterator_to_numpy_chunks,
                          iterator_to_DataFrame_chunks)
 from odo.chunks import chunks
 from datashape import discover, dshape
-from collections import Iterator
+from collections.abc import Iterator
 import datetime
 import datashape
 import numpy as np


### PR DESCRIPTION
Fixes #626.

`Iterator` and `Iterable` were moved to `collections.abc` in Python 3.3, and importing them from the `collections` top-level namespace was deprecated and **removed in Python 3.10** — so `from collections import Iterator` now raises `ImportError` on modern Python.

No behavioral change — purely an import-location fix for Python 3.10+ compatibility.